### PR TITLE
Add Dockerfile and kubernetes configurations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.3.5
+
+COPY . /acceptbitcoin
+WORKDIR /acceptbitcoin
+
+RUN bundle install
+
+EXPOSE 4000
+
+CMD [ "jekyll", "serve", "-H", "0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ bundle exec jekyll serve
 
 The acceptBitcoin.cash website should then be accessible from `http://localhost:4000`.
 
+## Docker
+
+acceptBitcoin.cash also includes a Docker image for easy deployment. You can build and run the Docker image using the following commands.
+
+```
+cd ~/acceptbitcoincash
+docker build -t acceptbitcoincash .
+docker run -p 4000:4000 acceptbitcoincash
+```
+
+The acceptBitcoin.cash website should then be accessible from `http://localhost:4000`.
+
 ## License
 
 This code is distributed under the MIT license. For more info, read the

--- a/kube/acceptbitcoincash-autoscale.yml
+++ b/kube/acceptbitcoincash-autoscale.yml
@@ -1,0 +1,13 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: acceptbitcoincash
+  namespace: default
+spec:
+  scaleTargetRef:
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    name: acceptbitcoincash
+  minReplicas: 2
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 90

--- a/kube/acceptbitcoincash-deployment.yml
+++ b/kube/acceptbitcoincash-deployment.yml
@@ -1,0 +1,23 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  namespace: default
+  labels:
+    service: acceptbitcoincash
+  name: acceptbitcoincash
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        service: acceptbitcoincash
+    spec:
+      containers:
+      - image: zquestz/acceptbitcoincash
+        name: acceptbitcoincash
+        ports:
+        - containerPort: 4000
+        resources:
+          requests:
+            memory: "64Mi"
+      restartPolicy: Always

--- a/kube/acceptbitcoincash-ingress.yml
+++ b/kube/acceptbitcoincash-ingress.yml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: acceptbitcoincash-ingress
+  namespace: default
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "gce"
+spec:
+  tls:
+  - hosts:
+    - acceptbitcoin.cash
+    secretName: acceptbitcoincash-tls
+  backend:
+    serviceName: acceptbitcoincash
+    servicePort: 90
+  rules:
+  - host: acceptbitcoin.cash
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: acceptbitcoincash
+          servicePort: 90

--- a/kube/acceptbitcoincash-srv.yml
+++ b/kube/acceptbitcoincash-srv.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: acceptbitcoincash
+  namespace: default
+spec:
+  ports:
+    - port: 90
+      targetPort: 4000
+  selector:
+    service: acceptbitcoincash
+  type: NodePort


### PR DESCRIPTION
This PR adds a Dockerfile, as well as Kubernetes configurations for acceptbitcoin.cash.

Directions are included in `README.md`