### PR TITLE
Change image reference for kubernetes

### DIFF
--- a/kube/acceptbitcoincash-deployment.yml
+++ b/kube/acceptbitcoincash-deployment.yml
@@ -13,7 +13,7 @@ spec:
         service: acceptbitcoincash
     spec:
       containers:
-      - image: zquestz/acceptbitcoincash
+      - image: acceptbitcoincash/acceptbitcoincash
         name: acceptbitcoincash
         ports:
         - containerPort: 4000


### PR DESCRIPTION
Just points the docker image to the new account on docker hub.