### PR TITLE
Update docker flow to use nginx instead of jekyll serve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,3 @@
-FROM ruby:2.3.5
-
-COPY . /acceptbitcoin
-WORKDIR /acceptbitcoin
-
-RUN bundle install
-
-EXPOSE 4000
-
-CMD [ "jekyll", "serve", "-H", "0.0.0.0"]
+FROM nginx
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY _site/ /usr/share/nginx/html/

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ acceptBitcoin.cash also includes a Docker image for easy deployment. You can bui
 
 ```
 cd ~/acceptbitcoincash
+gem install bundler
+bundle exec jekyll build
 docker build -t acceptbitcoincash .
 docker run -p 4000:4000 acceptbitcoincash
 ```

--- a/kube/acceptbitcoincash-deployment.yml
+++ b/kube/acceptbitcoincash-deployment.yml
@@ -16,7 +16,7 @@ spec:
       - image: acceptbitcoincash/acceptbitcoincash
         name: acceptbitcoincash
         ports:
-        - containerPort: 4000
+        - containerPort: 80
         resources:
           requests:
             memory: "64Mi"

--- a/kube/acceptbitcoincash-srv.yml
+++ b/kube/acceptbitcoincash-srv.yml
@@ -6,7 +6,7 @@ metadata:
 spec:
   ports:
     - port: 90
-      targetPort: 4000
+      targetPort: 80
   selector:
     service: acceptbitcoincash
   type: NodePort

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,32 @@
+server {
+    listen       80;
+    server_name  acceptbitcoin.cash;
+
+    if ( $http_x_forwarded_proto = 'http' ) {
+        return 301 https://$host$request_uri;
+    }
+
+    root   /usr/share/nginx/html;
+
+    location / {
+        index  index.html;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}
+
+## Compression.
+gzip on;
+gzip_buffers 16 8k;
+gzip_comp_level 1;
+gzip_http_version 1.1;
+gzip_min_length 10;
+gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+gzip_vary on;
+gzip_proxied any; # Compression for all requests.
+## No need for regexps. See
+## http://wiki.nginx.org/NginxHttpGzipModule#gzip_disable
+gzip_disable msie6;


### PR DESCRIPTION
This merely updates the docker image to use built assets in _site to serve via nginx instead of using jekyll serve. This allows us to use nginx.conf to customize things like redirects and https support.