### PR TITLE
Disable viewport scaling to fix layout issue

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,7 +5,7 @@
   <meta name="description" content="{{ site.description }}">
   <meta name="author" content="{{ site.author }}">
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0, user-scalable=no">
   <meta name="theme-color" content="#F7941D">
   <link rel="icon" type="image/png" href="/img/logo.png"/>
 


### PR DESCRIPTION
Chrome does some wonky things with sometimes creating extra space on the right, allowing you to pan around. This is a proposed fix that seems to do it so far, but please test.