### PR TITLE
Make sure to exclude kube directory from jekyll serve/build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,5 +20,6 @@ exclude:
     - verify.rb
     - vendor
     - kube
+    - nginx.conf
 
 theme: jekyll-theme-hacker

--- a/_config.yml
+++ b/_config.yml
@@ -19,5 +19,6 @@ exclude:
     - Rakefile
     - verify.rb
     - vendor
+    - kube
 
 theme: jekyll-theme-hacker


### PR DESCRIPTION
The kube directory was being built in the images. Luckily there are no secrets or sensitive information.

While I was there I also excluded nginx.conf as that doesn't need to be served.