### PR TITLE
If they only support withdrawals it's a no

### DIFF
--- a/_data/cryptoexchanges.yml
+++ b/_data/cryptoexchanges.yml
@@ -162,7 +162,7 @@ websites:
     - name: Coinbase
       url: https://www.coinbase.com/
       img: coinbase.png
-      bcc: Yes
+      bcc: No
       btc: Yes
       othercrypto: Yes
       doc: https://support.coinbase.com/customer/portal/articles/2853600-bitcoin-cash---frequently-asked-questions
@@ -297,7 +297,7 @@ websites:
     - name: Poloniex
       url: https://poloniex.com/
       img: poloniex.png
-      bcc: Yes
+      bcc: No
       btc: Yes
       othercrypto: Yes
       doc: https://poloniex.com/press-releases/2017.08.03-Bitcoin-Cash-Update/

--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -241,7 +241,7 @@ websites:
   - name: Xapo
     url: https://xapo.com
     img: xapo.png
-    bcc: Yes
+    bcc: No
     btc: Yes
     othercrypto: Yes
     doc: https://blog.xapo.com/xapo-bitcoincash-bch-update/

--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -296,7 +296,7 @@ websites:
       url: https://purse.io/
       img: purse.png
       twitter: PurseIO
-      bcc: Yes
+      bcc: No
       btc: Yes
       docs: https://blog.purse.io/announcement-update-bitcoin-cash/
       exceptions:

--- a/_data/wallets.yml
+++ b/_data/wallets.yml
@@ -34,12 +34,12 @@ websites:
     - name: Bread
       url: https://breadapp.com/
       img: bread.png
-      bcc: Yes
+      bcc: No
       btc: Yes
       othercrypto: Yes
       doc: https://breadapp.com/blog/breadwallet-plan-bitcoin-cash-bch/
       exceptions:
-      text: "Currently only allows withdrawals."
+          text: "Currently only allows withdrawals."
 
     - name: BTC.com
       url: https://wallet.btc.com/
@@ -85,7 +85,7 @@ websites:
     - name: Jaxx
       url: https://jaxx.io/
       img: jaxx.png
-      bcc: Yes
+      bcc: No
       btc: Yes
       doc: http://decentral.ca/update-bch-jaxx/
       exceptions:


### PR DESCRIPTION
So I went through and made the exceptions consistent. If they only support withdrawal then BCC support is not complete and we want people to reach out to them. Therefore it makes sense for these to be a NO.

The only exception that I kept as a yes was because the wallet had full support but was merely beta. =)

Also went ahead and fixed the exception for Bread.