### PR TITLE
Parse URL parameters for BCH-only filtering by default

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3,7 +3,11 @@ $(document).ready(function () {
 
   // Check if URL references specific category
   if (window.location.hash && window.location.hash.indexOf('#') > -1) {
-    openCategory(window.location.hash.substring(1));
+    if (window.location.hash == '#bch') {
+      $('#show-bcc-only').prop('checked', true);
+    } else {
+      openCategory(window.location.hash.substring(1));
+    }
   }
 
   // Some frilly animations on click of the main Bitcoin Cash logo
@@ -211,7 +215,7 @@ $('.z-switch').click(function () {
  * Check if the user wants to filter by Bitcoin Cash only
  */
 function BCCfilter() {
- if ($('#show-bcc-only').is(':checked')) {
+ if ( $('#show-bcc-only').is(':checked') || window.location.hash == '#bch' ) {
     $('.no-bcc').css('display', 'none');
     if (isSearching) jets.options.didSearch( $('#bcc-merchant-search').val() );
   } else {

--- a/js/app.js
+++ b/js/app.js
@@ -231,7 +231,7 @@ $('.z-switch').click(function () {
  * Check if the user wants to filter by Bitcoin Cash only
  */
 function BCCfilter() {
- if ( $('#show-bcc-only').is(':checked') || window.location.hash == '#bch' ) {
+ if ($('#show-bcc-only').is(':checked')) {
     $('.no-bcc').css('display', 'none');
     if (isSearching) jets.options.didSearch( $('#bcc-merchant-search').val() );
   } else {

--- a/js/app.js
+++ b/js/app.js
@@ -1,13 +1,29 @@
 // When DOM elements are ready, excluding images
 $(document).ready(function () {
 
+  // Get all URL parameters
+  var getUrlParameter = function getUrlParameter(sParam) {
+    var sPageURL = decodeURIComponent(window.location.search.substring(1)),
+      sURLVariables = sPageURL.split('&'),
+      sParameterName,
+      i;
+      
+    for (i = 0; i < sURLVariables.length; i++) {
+      sParameterName = sURLVariables[i].split('=');
+      if (sParameterName[0] === sParam) {
+        return sParameterName[1] === undefined ? true : sParameterName[1];
+      }
+    }
+  };
+
+  // Check if URL parameter exists to filter by BCH-only
+  if (getUrlParameter('filter') == 'bch') {
+    $('#show-bcc-only').prop('checked', true);
+  }
+
   // Check if URL references specific category
   if (window.location.hash && window.location.hash.indexOf('#') > -1) {
-    if (window.location.hash == '#bch') {
-      $('#show-bcc-only').prop('checked', true);
-    } else {
-      openCategory(window.location.hash.substring(1));
-    }
+    openCategory(window.location.hash.substring(1));
   }
 
   // Some frilly animations on click of the main Bitcoin Cash logo


### PR DESCRIPTION
i.e. https://acceptbitcoin.cash/#bch

Idea from https://www.reddit.com/r/btc/comments/78xcb4/you_can_now_filter_acceptbitcoincash_to_only/doxsnuf/ -- Resolves #221 