### PR TITLE
Improve display logic for 'collapse all' button

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -104,6 +104,7 @@ p {
     }
 
     &:nth-child(3) {
+      display: none;
       background-color: $green-light !important;
       position: absolute;
       top: -128px;

--- a/js/app.js
+++ b/js/app.js
@@ -7,7 +7,7 @@ $(document).ready(function () {
       sURLVariables = sPageURL.split('&'),
       sParameterName,
       i;
-      
+
     for (i = 0; i < sURLVariables.length; i++) {
       sParameterName = sURLVariables[i].split('=');
       if (sParameterName[0] === sParam) {
@@ -64,6 +64,7 @@ $(document).ready(function () {
       var body = $("html, body");
       body.stop().animate({scrollTop: $('.category h5 i.active-icon').offset().top - 120}, 1000, 'swing');
       $('.category h5 i').removeClass('active-icon');
+      $(this).css('display', 'none');
     } else {
       if ($(this).hasClass('attention')) {
         $(this).removeClass('attention');
@@ -260,6 +261,7 @@ function openCategory(category) {
   // Close all active categories
   $('.category h5 i').removeClass('active-icon');
   $('.website-table').css('display', 'none');
+  $('.fab button:nth-child(3)').css('display', 'inline-block');
   BCCfilter();
 
   // Place the category being viewed in the URL bar
@@ -293,4 +295,5 @@ function closeCategory(category) {
   $('.' + category + '-table').slideUp();
   $('#' + category + ' h5 i').removeClass('active-icon');
   history.pushState('', document.title, window.location.pathname);
+  $('.fab button:nth-child(3)').css('display', 'none');
 }

--- a/js/app.js
+++ b/js/app.js
@@ -65,6 +65,7 @@ $(document).ready(function () {
       body.stop().animate({scrollTop: $('.category h5 i.active-icon').offset().top - 120}, 1000, 'swing');
       $('.category h5 i').removeClass('active-icon');
       $(this).css('display', 'none');
+      document.location.hash = '';
     } else {
       if ($(this).hasClass('attention')) {
         $(this).removeClass('attention');


### PR DESCRIPTION
Only shows the 'collapse all' floating action button when a category is open. This keeps things cleaner when displaying search results too (as there was no way to collapse the results).