### PR TITLE
Updated Air VPN to show as supporting BTC and BCH.

### DIFF
--- a/_data/security.yml
+++ b/_data/security.yml
@@ -2,7 +2,8 @@ websites:
     - name: Air VPN
       url: https://airvpn.org/
       img: airvpn.png
-      bcc: No
+      bcc: Yes
+      btc: Yes
       twitter: airvpn
       facebook: airvpn.org
 


### PR DESCRIPTION
Air VPN supports both according to their plans page:

  https://airvpn.org/plans/