### PR TITLE
Visual indication for categories that have zero merchants accepting BCH

### DIFF
--- a/_data/sections.yml
+++ b/_data/sections.yml
@@ -6,9 +6,9 @@
   title: Backup and Sync
   icon: disk outline
 
-- id: banking
-  title: Banking
-  icon: dollar
+#- id: banking
+# title: Banking
+#  icon: dollar
 
 - id: cloud
   title: Cloud Computing

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -1,11 +1,18 @@
 {% assign section_id = include.id-param %}
 {% assign section_title = include.title-param %}
 {% assign section_file = site.data[section_id] %}
+{% assign count_bcc = 0 %}
+{% for website in section_file.websites %}
+  {% if website.bcc %}
+    {% assign count_bcc = count_bcc | plus: '1' %}
+  {% endif %}
+{% endfor %}
+
 <div class="website-table desktop-table {{ section_id }}-table" id="{{ section_id }}-desktoptable" style="display:none">
   <table class="ui celled table content-wrapper">
     <thead class="ui sticky">
     <tr>
-      <th class="single line four wide"><h3>{{ section_title }}</h3></th>
+      <th class="single line four wide"><h3>{{ section_title }} ({{ count_bcc }})</h3></th>
       <th class="two wide">Bitcoin Cash</th>
       <th class="two wide">Bitcoin (Legacy)</th>
       <th class="two wide">Other Crypto</th>
@@ -13,9 +20,9 @@
     </tr>
     </thead>
     <tbody class="bcc-merchant-content">
-      {% if section_file.websites.size == null %}
-      <tr class="desktop-tr">
-        <td colspan="5" style="text-align: center"><h3><i class="big remove circle icon"></i></h3> Nothing found.</td>
+      {% if count_bcc <= 0 %}
+      <tr class="bcc-only-none-found">
+        <td colspan="5" style="text-align: center"><h3><i class="big remove circle icon"></i></h3> No merchants accepting Bitcoin Cash found in {{section_title}}.</td>
       </tr>
       {% endif %}
       {% for website in section_file.websites %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -1,15 +1,22 @@
 {% assign section_id = include.id-param %}
 {% assign section_title = include.title-param %}
 {% assign section_file = site.data[section_id] %}
+{% assign count_bcc = 0 %}
+{% for website in section_file.websites %}
+  {% if website.bcc %}
+    {% assign count_bcc = count_bcc | plus: '1' %}
+  {% endif %}
+{% endfor %}
+
 <div class="website-table mobile-table {{ section_id }}-table" id="{{ section_id }}-mobiletable" style="display:none">
   <div class="label">
     <h3>{{ section_title }}</h3>
   </div>
   <div class="bcc-merchant-content">
-    {% if section_file.websites.size == null %}
-    <div class="main negative{% if website.bcc == false %} no-bcc{% endif %}">
+    {% if count_bcc <= 0 %}
+    <div class="main negative{% if website.bcc == false %} no-bcc{% endif %} bcc-only-none-found-mobile">
       <div class="title">
-        <i class="big remove circle icon"></i> Nothing found.
+        <i class="big remove circle icon"></i>No merchants accepting Bitcoin Cash found in {{section_title}}.
       </div>
     </div>
     {% endif %}

--- a/css/base.scss
+++ b/css/base.scss
@@ -215,7 +215,7 @@ p {
     padding: 10px 0;
     background: $blue;
     border-radius: 0 0 10px 10px;
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-style: italic;
     font-weight: 500;
 
@@ -545,6 +545,10 @@ p {
 
 .ui.table td.twitter {
   text-align: center;
+}
+
+.bcc-only-none-found {
+  display: none;
 }
 
 .website-table {
@@ -1039,7 +1043,7 @@ span.progress {
 
             .z-switch--container {
               float: left;
-              margin: 0 10px 0 0;
+              margin: 3px 10px 0 0;
             }
           }
         }

--- a/index.html
+++ b/index.html
@@ -48,14 +48,14 @@ hash: acceptBitcoinCash
       <svg version="1.1" id="coin_side_left" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
         width="90px" height="200px" viewBox="0 0 549 1186" xml:space="preserve">
         <path d="M549.068,1186
-					c-186.543-130.974-308.48-347.74-308.48-593S362.525,130.973,549.068,0H4.85v1186H549.068z"/>
+          c-186.543-130.974-308.48-347.74-308.48-593S362.525,130.973,549.068,0H4.85v1186H549.068z"/>
       </svg>
     </div>
     <div class="coin-side left-side">
       <svg version="1.1" id="coin_side_left" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
         width="90px" height="200px" viewBox="0 0 549 1186" xml:space="preserve">
         <path d="M549.068,1186
-					c-186.543-130.974-308.48-347.74-308.48-593S362.525,130.973,549.068,0H4.85v1186H549.068z"/>
+          c-186.543-130.974-308.48-347.74-308.48-593S362.525,130.973,549.068,0H4.85v1186H549.068z"/>
       </svg>
     </div>
     <input type="checkbox" id="coin-toggle">
@@ -97,7 +97,7 @@ hash: acceptBitcoinCash
               <i class="remove icon"></i>
             </button>
           </label>
-          <label class="z-switch">
+          <label for="show-bcc-only" class="z-switch">
             <input type="checkbox" id="show-bcc-only">
               <div class="z-switch--container">
                   <div class="z-switch--slider"></div>
@@ -146,33 +146,50 @@ hash: acceptBitcoinCash
     <div class="five column row">
       {% assign rowcount = 0 %}
       {% for section in site.data.sections %}
-      {% assign rowend = forloop.index | modulo: 5 %}
-      {% if rowend == 0 or forloop.index == forloop.length %}
-      <div id="{{ section.id }}" class="category column">
-        <h5 class="ui icon header">
-          <i class="circular {{ section.icon }} icon"></i>
-          <small>{{ section.title }}</small>
-        </h5>
-      </div>
-      {% include mobile-table.html id-param=section.id title-param=section.title %}
-      {% assign offcount = 5 | times: rowcount %}
-      {% for section in site.data.sections limit: 5 offset: offcount %}
-      {% include desktop-table.html id-param=section.id title-param=section.title %}
-      {% endfor %}
-    </div>
-    {% if forloop.index != forloop.length %}
-    {% assign rowcount = rowcount | plus: '1' %}
-    <div class="five column row">
-    {% endif %}
-      {% else %}
-      <div id="{{ section.id }}" class="category column">
-        <h5 class="ui icon header">
-          <i class="circular {{ section.icon }} icon"></i>
-          <small>{{ section.title }}</small>
-        </h5>
-      </div>
-      {% include mobile-table.html id-param=section.id title-param=section.title %}
-      {% endif %}
+        {% assign current_section = site.data[section.id] %}
+        {% assign rowend = forloop.index | modulo: 5 %}
+
+        {% assign count_bcc = 0 %}
+        {% for website in current_section.websites %}
+          {% if website.bcc %}
+            {% assign count_bcc = count_bcc | plus: '1' %}
+          {% endif %}
+        {% endfor %}
+
+        {% if rowend == 0 or forloop.index == forloop.length %}
+          {% if count_bcc == 0 %}
+          <div id="{{ section.id }}" class="category column bcc-only-hidden">
+          {% else %}
+          <div id="{{ section.id }}" class="category column">
+          {% endif %}
+            <h5 class="ui icon header">
+              <i class="circular {{ section.icon }} icon"></i>
+              <small>{{ section.title }}</small>
+            </h5>
+          </div>
+          {% include mobile-table.html id-param=section.id title-param=section.title %}
+          {% assign offcount = 5 | times: rowcount %}
+          {% for section in site.data.sections limit: 5 offset: offcount %}   
+            {% include desktop-table.html id-param=section.id title-param=section.title %}
+          {% endfor %}
+          </div>
+          {% if forloop.index != forloop.length %}
+            {% assign rowcount = rowcount | plus: '1' %}
+            <div class="five column row">
+          {% endif %}
+        {% else %}
+          {% if count_bcc == 0 %}
+          <div id="{{ section.id }}" class="category column bcc-only-hidden">
+          {% else %}
+          <div id="{{ section.id }}" class="category column">
+          {% endif %}
+            <h5 class="ui icon header">
+              <i class="circular {{ section.icon }} icon"></i>
+              <small>{{ section.title }}</small>
+            </h5>
+          </div>
+          {% include mobile-table.html id-param=section.id title-param=section.title %}
+        {% endif %}
       {% endfor %}
     </div>
   </div>

--- a/js/app.js
+++ b/js/app.js
@@ -243,8 +243,13 @@ $('.z-switch').click(function () {
 function BCCfilter() {
  if ($('#show-bcc-only').is(':checked')) {
     $('.no-bcc').css('display', 'none');
+    $('.bcc-only-none-found').css('display', 'table-row');
+    $('.bcc-only-none-found-mobile').css('display', 'block');
+    $('.bcc-only-hidden').css('opacity', '0.4');
     if (isSearching) jets.options.didSearch( $('#bcc-merchant-search').val() );
   } else {
+    $('.bcc-only-none-found, .bcc-only-none-found-mobile').css('display', 'none');
+    $('.bcc-only-hidden').css('opacity', '1');
     $('.mobile-table .no-bcc').css('display', 'block');
     $('.desktop-table .no-bcc').css('display', 'table-row');
     if (isSearching) jets.options.didSearch( $('#bcc-merchant-search').val() );


### PR DESCRIPTION
This dims the opacity of categories that do not have any BCH-accepting merchants listed, and shows a message (if that category is expanded) when the BCH-only filter is applied. 

![image](https://user-images.githubusercontent.com/31756199/33698870-5d3e67f6-dadd-11e7-8395-9e0f17287786.png)

Closes #259 

