### PR TITLE
Add docker:build to the Rakefile

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+acceptbitcoincash

--- a/Rakefile
+++ b/Rakefile
@@ -32,7 +32,7 @@ task proof_external: 'build' do
   ).run
 end
 
-namespace :docker  do
+namespace :docker do
   desc "build docker images"
   task :build do
     puts "Generating static files for nginx"

--- a/Rakefile
+++ b/Rakefile
@@ -32,6 +32,16 @@ task proof_external: 'build' do
   ).run
 end
 
+namespace :docker  do
+  desc "build docker images"
+  task :build do
+    puts "Generating static files for nginx"
+    puts `bundle exec jekyll build`
+    puts "Building acceptbitcoincash docker image"
+    puts `docker build -t acceptbitcoincash/acceptbitcoincash .`
+  end
+end
+
 task :verify do
   ruby './verify.rb'
 end


### PR DESCRIPTION
Just adds `rake docker:build` to generate a docker image. Also adds a .ruby-gemset file which can be quite convenient.