### PR TITLE
Embed Twitter timeline of "usebitcoin.cash" + Follow button

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -55,6 +55,13 @@
 <!-- ./scripts/python/bchAccepted.py must be run at build time to generate/update the following include: -->
 {% include count_support.html %}
 
+<div class="ui center aligned segment twitter-panel">
+  <a class="twitter-timeline" data-dnt="true" data-theme="light" data-width="705" href="https://twitter.com/search?q=usebitcoin.cash" data-widget-id="939960678953218048">Tweets about usebitcoin.cash</a>
+  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+  <br><br>
+  <a href="https://twitter.com/useBitcoinCash?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-dnt="true" data-show-count="false">Follow @useBitcoinCash</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</div>
+
 <div class="ui center aligned ticker">
   <ul id="ticker_value">
     <li>Loading&hellip;</li>
@@ -229,11 +236,11 @@
   </div>
 
   <p><b>Looking for various types of Bitcoin Cash logos, images, POS signage, etc.?</b><br>Below you'll find high-resolution assets provided by community members.</p>
-  <a id="toggle-assets">
+  <a id="assets">
     <i class="image icon"></i>
     Image Assets
   </a>
-  <a id="toggle-art-collections">
+  <a id="art-collections">
     <i class="qrcode icon"></i>
     Artwork Collections
   </a>


### PR DESCRIPTION
Hoping that this encourages interactivity with the merchant Tweet buttons:

![image](https://user-images.githubusercontent.com/31756199/33816118-d1f9cb1a-de04-11e7-9212-9a77d4fdf84c.png)
