### PR TITLE
Correct No-ip.com in domains; this site accepts legacy Bitcoin

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -415,6 +415,7 @@ websites:
       btc: yes
       twitter: NoIPcom
       facebook: noipdns
+      doc: https://www.noip.com/bitcoin
 
     - name: Nominet
       url: http://www.nominet.uk/

--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -412,6 +412,7 @@ websites:
       url: https://www.noip.com/
       img: noip.png
       bch: No
+      btc: yes
       twitter: NoIPcom
       facebook: noipdns
 


### PR DESCRIPTION
Small PR to correct no-ip.com's currency options.

I've used No-ip for several years and they've accepted legacy Bitcoin for some time now. There's a page on their site dedicated to using Bitcoin for their services: https://www.noip.com/bitcoin. It's also included in their support pages as an accepted method of payment.

Now let's get them using BCH!