### PR TITLE
Improve handling of missing images

### DIFF
--- a/_data/backup.yml
+++ b/_data/backup.yml
@@ -43,14 +43,14 @@ websites:
     bch: No
     btc: No
     othercrypto: No
-    
-    - name: Boxcryptor
-      url: https://www.boxcryptor.com
-      img: boxcryptor.png
-      bch: No
-      twitter: boxcryptor
-      facebook: boxcryptor
-      email_address: info@boxcryptor.com
+
+  - name: Boxcryptor
+    url: https://www.boxcryptor.com
+    img: boxcryptor.png
+    bch: No
+    twitter: boxcryptor
+    facebook: boxcryptor
+    email_address: info@boxcryptor.com
 
   - name: CloudApp
     url: https://www.getcloudapp.com/

--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -147,7 +147,7 @@ websites:
     url: https://cryptograffiti.info
     img: cryptograffiti.png
     bch: Yes
-    
+
   - name: Cryptonize.it
     url: https://www.cryptonize.it
     twitter: cryptonize_it
@@ -174,7 +174,7 @@ websites:
     bch: Yes
     btc: Yes
     othercrypto: Yes
-    
+
   - name: Gyft
     url: https://www.gyft.com/
     img: gyft.png
@@ -183,7 +183,7 @@ websites:
     bch: No
     btc: Yes
     othercrypto: No
-    
+
   - name: Incognito Deals
     url: https://www.incognitodeals.com/index.html
     img: incognitoDeals.png
@@ -191,7 +191,7 @@ websites:
     bch: Yes
     btc: No
     othercrypto: Yes
-    
+
   - name: Insight
     url: https://insight.bitpay.com/
     img: insight.png
@@ -230,7 +230,6 @@ websites:
 
   - name: LocalBitcoinCash
     url: https://localbitcoincash.org
-    img: generic.png
     bch: Yes
 
   - name: Living Room of Satoshi
@@ -272,8 +271,8 @@ websites:
     btc: yes
     othercrypto: yes
     doc: https://www.privcoin.io/bitcoincash/
-    
-    
+
+
   - name: Purse
     url: https://purse.io/
     img: purse.png

--- a/_includes/desktop-table.html
+++ b/_includes/desktop-table.html
@@ -43,8 +43,10 @@
             <div class="title">
               {% if website.img %}
                 <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-                <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                     alt="{{ website.name }}">
+                <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+              {% else %}
+                <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+                <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
               {% endif %}
               <a class="name" href="{{ website.url }}" target="_blank">{{ website.name }}</a>
               {% include exception.html website=website %}
@@ -64,6 +66,9 @@
               {% if website.img %}
                 <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
                 <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+              {% else %}
+                <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+                <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
               {% endif %}
               <a class="name" href="{{ website.url }}" target="_blank">{{ website.name }}</a>
               {% include exception.html website=website %}
@@ -111,8 +116,10 @@
             <div class="title">
               {% if website.img %}
                 <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-                <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-                     alt="{{ website.name }}">
+                <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+              {% else %}
+                <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+                <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
               {% endif %}
               <a class="name" href="{{ website.url }}" target="_blank">{{ website.name }}</a>
               {% include exception.html website=website %}

--- a/_includes/mobile-table.html
+++ b/_includes/mobile-table.html
@@ -35,8 +35,10 @@
       <div class="title">
         {% if website.img %}
         <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-             alt="{{ website.name }}">
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+        {% else %}
+        <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
         {% endif %}
         <a href="{{ website.url }}" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
@@ -58,6 +60,9 @@
         {% if website.img %}
         <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
         <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+        {% else %}
+        <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
         {% endif %}
         <a href="{{ website.url }}" target="_blank" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}
@@ -97,8 +102,10 @@
       <div class="title">
         {% if website.img %}
         <noscript><img src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}"></noscript>
-        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon"
-             alt="{{ website.name }}">
+        <img src="/img/placeholder.png" data-src="/img/{{ section_id }}/{{ website.img }}" class="icon" alt="{{ website.name }}">
+        {% else %}
+        <noscript><img src="/img/placeholder.png" class="icon" alt="{{ website.name }}"></noscript>
+        <img src="/img/placeholder.png" data-src="/img/placeholder.png" class="icon">
         {% endif %}
         <a href="{{ website.url }}" target="_blank" class="name">{{ website.name }}</a>
         {% include exception.html website=website %}


### PR DESCRIPTION
Cleanly falls back to 'img/placeholder.png' if no 'img:' is defined in YAML. (Plus a few other small fixes)