### PR TITLE
Document how to run docker with SELinux enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you are doing development, and want to launch a jekyll server which can track
 
 ```
 cd ~/acceptbitcoincash
-docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
+docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll:z \
   -it -p 127.0.0.1:4000:4000 jekyll/jekyll:latest jekyll s
 ```
 


### PR DESCRIPTION
SELinux will not let Docker access the files without this change.

How it fails without the :z suffix:
```
jonny@localhost ~/projects/acceptbitcoincash (hegjon-selinux) {1.8}{6.12.3} $ docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll   -it -p 127.0.0.1:4000:4000 jekyll/jekyll:latest jekyll s
chown: .sass-cache: Permission denied
```
