### PR TITLE
Because there is donation category now, no need exception

### DIFF
--- a/_data/donation-software.yml
+++ b/_data/donation-software.yml
@@ -25,8 +25,6 @@ websites:
       btc: Yes
       othercrypto: Yes
       doc: https://getsharex.com/donate/
-      exceptions:
-        text: "ShareX is free but accepts donations"
         
     - name: Tor Project
       url: https://www.torproject.org/


### PR DESCRIPTION
Exception was added before donation category, now it is unnecessary.