### PR TITLE
Small meta tweaks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'html-proofer'
 require 'rubocop/rake_task'
 require 'jekyll'
 
@@ -15,6 +14,7 @@ task :build do
 end
 
 task proof: 'build' do
+  require 'html-proofer'
   HTMLProofer.check_directory(
     './_site', \
     assume_extension: true, \
@@ -26,6 +26,7 @@ task proof: 'build' do
 end
 
 task proof_external: 'build' do
+  require 'html-proofer'
   HTMLProofer.check_directory(
     './_site', \
     assume_extension: true, \

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ title: The Accept Bitcoin Cash Initiative
 author: n9jd34x04l151ho4 + topolino + kenman345
 description:
     Community-curated list of sites/merchants that accept Bitcoin Cash.
-url: https://AcceptBitcoin.Cash
+url: https://usebitcoin.cash
 repo: https://github.com/acceptbitcoincash/acceptbitcoincash
 img: img/logo.png
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ title: The Accept Bitcoin Cash Initiative
 author: n9jd34x04l151ho4 + topolino + kenman345
 description:
     Community-curated list of sites/merchants that accept Bitcoin Cash.
-url: https://usebitcoin.cash
+url: https://AcceptBitcoin.Cash
 repo: https://github.com/acceptbitcoincash/acceptbitcoincash
 img: img/logo.png
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,8 @@ description:
 url: https://usebitcoin.cash
 repo: https://github.com/acceptbitcoincash/acceptbitcoincash
 img: img/logo.png
+twitter:
+  username: useBitcoinCash
 sass:
     style: compressed
 plugins:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0">
   <meta name="theme-color" content="#F7941D">
-
+{% seo %}
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=478559">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png?v=478559">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png?v=478559">
@@ -15,12 +15,6 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg?v=478559" color="#5bbad5">
   <link rel="shortcut icon" href="/favicon.ico?v=478559">
   <meta name="theme-color" content="#ffffff">
-
-  <meta property="og:title" content="{{ site.title }}">
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="{{ site.url }}/{{ site.img }}">
-  <meta property="og:url" content="{{ site.url }}">
-  <meta property="og:description" content="{{ page.description }}">
 
   <title>{{ site.title }}</title>
 


### PR DESCRIPTION
@t0p0lin0  I need you to approve this. the `{% seo %}` tag gives us the SEO tags inherently. And currently our tags were not getting picked up as well as they could have by sites like: https://richpreview.com/?url=https%3A%2F%2Facceptbitcoin.cash%2F