### PR TITLE
Add 'Vanity Cash' to the 'Cryptoservices' category

### DIFF
--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -602,3 +602,11 @@ websites:
   bch: Yes
   btc: No
   othercrypto: No
+- name: Vanity Cash
+  url: https://vanity.cash
+  img: VanityCash.png
+  bch: Yes
+  btc: No
+  othercrypto: No
+  twitter: coin_dance
+  email_address: david@blockchain.ventures


### PR DESCRIPTION
This closes #1372.

Requesting to add 'Vanity Cash' to the 'Cryptoservices' category. 

Details follow: 
```yml 
- name: Vanity Cash
  url: https://vanity.cash
  img: VanityCash.png
  bch: Yes
  btc: No
  othercrypto: No
  twitter: coin_dance
  email_address: david@blockchain.ventures
```


Resources for adding this merchant:
Logo Provided:
![Vanity Cash](https://vanity.cash/assets/image/vcLogo.png)
Twitter Profile Image (48x48):
![Vanity Cash](https://pbs.twimg.com/profile_images/788566140104486912/8cT9IGPX_normal.jpg)
[Link to Vanity Cash](https://vanity.cash)
If needed, try the twitter handles profile image: [twitter.com/coin_dance](https://twitter.com/coin_dance)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/vanity.cash](https://www.alexa.com/siteinfo/vanity.cash)
Maybe you might want to check Scam Adviser: [https://www.scamadviser.com/check-website/vanity.cash](https://www.scamadviser.com/check-website/vanity.cash)
Maybe you might want to check Trust Pilot: [https://www.trustpilot.com/review/vanity.cash](https://www.trustpilot.com/review/vanity.cash)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by @kenman345
Request made by Twitter user [kenman345](https://twitter.com/kenman345/), be sure to send out a tweet when this request has been added.
