### PR TITLE
Add 'The Hygiology Post' to the 'Merchant and Website' category

### DIFF
--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -625,3 +625,12 @@ websites:
   doc: https://coinatmradar.com/manufacturer/93/dobi-atm-bitcoin-atm-producer/
   exceptions: 
     text: "yes. Users have cash or bank card through Bitcoin ATM to use Bitcoin Cash"
+- name: The Hygiology Post
+  url: https://hygiologypost.com/
+  img: TheHygiologyPost.png 
+  bch: Yes
+  btc: Yes
+  othercrypto: Yes
+  region: na
+  exceptions: 
+    text: "This method seems most direct and cost efficient. E Mail cryptocurrency@hygiologypost.com and identify what you purchased, the full address to where you physically want it sent (unless a Webstore product), and what cryptocurrency payment in full amt. was sent to the public cryptocurrency address below (please also account for any transaction fees charged). A coupon code for Webstore listings will be sent upon receipt of payment in full (can use conversion calculator from link below). Thank You! "


### PR DESCRIPTION
Requesting to add '  The Hygiology Post ®' to the 'Merchant and Website' category. 

Details follow: 
```yml 
- name: The Hygiology Post
      url: https://hygiologypost.com/
      img: 
      region: na
      bch: Yes
      btc: Yes
      othercrypto: Yes
```


Resources for adding this merchant:
[Link to   The Hygiology Post ®](https://hygiologypost.com/)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/hygiologypost.com/](https://www.alexa.com/siteinfo/hygiologypost.com/)
Maybe you might want to check Scam Adviser: [https://www.scamadviser.com/check-website/hygiologypost.com/](https://www.scamadviser.com/check-website/hygiologypost.com/)
Maybe you might want to check Trust Pilot: [https://www.trustpilot.com/review/hygiologypost.com/](https://www.trustpilot.com/review/hygiologypost.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.
