### PR TITLE
Add 'OnlineBee.in Short URL' to the 'Gamimg' category

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -524,3 +524,15 @@ websites:
   othercrypto: true
   keywords:
   - coinify
+- name: OnlineBee.in Short URL
+  url: http://onlinebee.in/
+  img: 
+  twitter: kanokwan24
+  email_address: nok141829@gmail.com
+  region: as
+  city: Thailand
+  bch: Yes
+  btc: Yes
+  othercrypto: Yes
+  exceptions: 
+    text: "Bitcoin"


### PR DESCRIPTION
Requesting to add 'OnlineBee.in Short URL' to the 'Gamimg' category. 

Details follow: 
```yml 
- name: OnlineBee.in Short URL
  url: http://onlinebee.in/
  img: 
  twitter: kanokwan24
  email_address: nok141829@gmail.com
  region: as
  city: Thailand
  bch: Yes
  btc: Yes
  othercrypto: Yes
  exceptions: 
    text: "Bitcoin"
```


Resources for adding this merchant:
Logo Provided:
![OnlineBee.in Short URL](http://aalyafaucet.com/img/ob-468.gif)

[Link to OnlineBee.in Short URL](http://onlinebee.in/)
If needed, try the twitter handles profile image: [twitter.com/kanokwan24](https://twitter.com/kanokwan24)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/onlinebee.in](https://www.alexa.com/siteinfo/onlinebee.in)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.
