### PR TITLE
Add 'sci-hub' to the 'Science and Research' category

### DIFF
--- a/_data/donation-software.yml
+++ b/_data/donation-software.yml
@@ -39,7 +39,7 @@ websites:
   facebook: 
   region: eu
   country: AT
-  city: Bad Vöslau
+  city: Bad V?slau
   bch: true
   btc: true
   othercrypto: false
@@ -218,3 +218,11 @@ websites:
   btc: true
   othercrypto: false
   doc: https://winscp.net/donate.php
+- name: sci-hub
+  url: https://sci-hub.tw/
+  img: 
+  twitter: Sci_Hub
+  facebook: sci.hub.org
+  bch: No
+  btc: Yes
+  othercrypto: No


### PR DESCRIPTION
Requesting to add 'sci-hub' to the 'Science and Research' category. 

Details follow: 
```yml 
- name: sci-hub
  url: https://sci-hub.tw/
  img: 
  twitter: Sci_Hub
  facebook: sci.hub.org
  bch: No
  btc: Yes
  othercrypto: No
```


Resources for adding this merchant:
Logo Provided:
![sci-hub](https://sci-hub.tw/misc/img/raven_1.png)

[Link to sci-hub](https://sci-hub.tw/)
If needed, try the twitter handles profile image: [twitter.com/Sci_Hub](https://twitter.com/Sci_Hub)
If needed, try the facebook handles profile image: [fb.com/sci.hub.org](https://fb.com/sci.hub.org)


- Verify site is legitimate and safe to list.
- Correct data in form if any is innacurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with 'closes #[ISSUE NUMBER HERE]'.
