### PR TITLE
Add 'Vero Servers' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -840,6 +840,15 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: Vero Servers
+  url: https://www.veroservers.com/
+  img: VeroServers.png 
+  bch: true
+  btc: true
+  othercrypto: true
+  twitter: veroservers
+  email_address: contact@veroservers.com
+  region: eu
 - name: Versio
   url: https://www.versio.nl
   twitter: versio


### PR DESCRIPTION
Requesting to add 'Vero Servers' to the 'Hosting' category. 

Details follow: 
```yml 
- name: Vero Servers
  url: https://www.veroservers.com/
  img: VeroServers.png 
  bch: true
  btc: true
  othercrypto: true
  twitter: veroservers
  email_address: contact@veroservers.com
  region: eu
```


Resources for adding this merchant:
Twitter Profile Image (48x48):
![TwitterProfileImageURL](https://pbs.twimg.com/profile_images/1006922093005561856/1aXEwxqM_normal.jpg)
[Link to Vero Servers](https://www.veroservers.com/)
If needed, try the twitter handles profile image: [twitter.com/veroservers](https://twitter.com/veroservers)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/www.veroservers.com/](https://www.alexa.com/siteinfo/www.veroservers.com/)
Maybe you might want to check Scam Adviser: [https://www.scamadviser.com/check-website/www.veroservers.com/](https://www.scamadviser.com/check-website/www.veroservers.com/)
Maybe you might want to check Trust Pilot: [https://www.trustpilot.com/review/www.veroservers.com/](https://www.trustpilot.com/review/www.veroservers.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

