### PR TITLE
GloBee no longer supports Bitcoin Cash

### DIFF
--- a/_data/payments.yml
+++ b/_data/payments.yml
@@ -196,13 +196,6 @@ websites:
   url: https://flattr.com
   twitter: flattr
   bch: false
-- name: GloBee
-  url: https://globee.com/
-  img: globee.png
-  twitter: GlobeeCom
-  bch: true
-  btc: true
-  othercrypto: true
 - name: GoCardless
   img: gocardless.png
   url: https://gocardless.com/


### PR DESCRIPTION
As per their [announcement](https://intercom.help/globee-72a616397ce3/faq-s/globee-and-bch-hit-splitsville), the GloBee payment service stopped accepting Bitcoin Cash. They are listed in the Payments category.