### PR TITLE
Add 'X CryptoMarket' to the 'Online Marketplace - P2P' category

### DIFF
--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -589,6 +589,12 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: X CryptoMarket
+  url: https://xcryptomarket.com
+  img: XCryptoMarket.png 
+  bch: true
+  btc: true
+  othercrypto: true
 - name: Xapo
   url: https://xapo.com
   img: xapo.png


### PR DESCRIPTION
Requesting to add 'X CryptoMarket' to the 'Online Marketplace - P2P' category. 

Details follow: 
```yml 
- name: X CryptoMarket
  url: https://xcryptomarket.com
  img: XCryptoMarket.png 
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to X CryptoMarket](https://xcryptomarket.com)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/xcryptomarket.com](https://www.alexa.com/siteinfo/xcryptomarket.com)
Maybe you might want to check Scam Adviser: [https://www.scamadviser.com/check-website/xcryptomarket.com](https://www.scamadviser.com/check-website/xcryptomarket.com)
Maybe you might want to check Trust Pilot: [https://www.trustpilot.com/review/xcryptomarket.com](https://www.trustpilot.com/review/xcryptomarket.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

