### PR TITLE
Add 'schnitzelears German and English classes' to the 'Education' category

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -295,6 +295,13 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: schnitzelears German and English classes
+  url: https://schnitzelears.com
+  img: schnitzelearsGermanandEnglishclasses.png 
+  bch: true
+  btc: false
+  othercrypto: true
+  email_address: schnitzelears@gmail.com
 - name: SchoolSoft
   url: http://schoolsoft.se/
   img: schoolsoft.png


### PR DESCRIPTION
Requesting to add 'schnitzelears German and English classes' to the 'Education' category. 

Details follow: 
```yml 
- name: schnitzelears German and English classes
  url: https://schnitzelears.com
  img: schnitzelearsGermanandEnglishclasses.png 
  bch: true
  btc: false
  othercrypto: true
  email_address: schnitzelears@gmail.com
```


Resources for adding this merchant:
[Link to schnitzelears German and English classes](https://schnitzelears.com)
Maybe you might want to check their Alexa Rank: [https://www.alexa.com/siteinfo/schnitzelears.com](https://www.alexa.com/siteinfo/schnitzelears.com)
Maybe you might want to check Scam Adviser: [https://www.scamadviser.com/check-website/schnitzelears.com](https://www.scamadviser.com/check-website/schnitzelears.com)
Maybe you might want to check Trust Pilot: [https://www.trustpilot.com/review/schnitzelears.com](https://www.trustpilot.com/review/schnitzelears.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

