### PR TITLE
Add 'Art by Matt Habel' to the 'Art' category

### DIFF
--- a/_data/art.yml
+++ b/_data/art.yml
@@ -8,6 +8,14 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: Art by Matt Habel
+  url: https://www.etsy.com/shop/matthabel
+  img: ArtbyMattHabel.png
+  bch: true
+  btc: true
+  othercrypto: true
+  exceptions:
+    text: "Checkout using 'Other' as the payment method then message me for payment address."
 - name: ARTLy
   url: https://shop.gohuozumi.com/
   img: artly.png
@@ -108,9 +116,9 @@ websites:
 - name: Dope! Gallery
   url: https://dope.gallery
   img: DopeGallery.png
-  bch: Yes
-  btc: Yes
-  othercrypto: No
+  bch: true
+  btc: true
+  othercrypto: false
   facebook: letartbeyourdope
   email_address: info@dope.gallery
   region: as


### PR DESCRIPTION
Requesting to add 'Art by Matt Habel' to the 'Art' category. 

Details follow: 
```yml 
- name: Art by Matt Habel
  url: https://www.etsy.com/shop/matthabel
  img: ArtbyMattHabel.png
  bch: true
  btc: true
  othercrypto: true
  exceptions:
    text: "Checkout using 'Other' as the payment method then message me for payment address."
```


Resources for adding this merchant:
[Link to Art by Matt Habel](https://www.etsy.com/shop/matthabel)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.etsy.com/shop/matthabel)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.etsy.com/shop/matthabel)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.etsy.com/shop/matthabel)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

