### PR TITLE
Add 'Apex Health' to the 'Health' category

### DIFF
--- a/_data/health.yml
+++ b/_data/health.yml
@@ -33,6 +33,15 @@ websites:
   keywords:
   - bitpay
   - bip70
+- name: Apex Health
+  url: https://www.apexhealth.club
+  img: apexhealth.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: offgridvoluntaryist@gmail.com
+  exceptions:
+    text: "Simply contact website host to arrange payment."
 - name: Aveon Health
   url: http://aveonhealth.com
   twitter: aveonhealth

--- a/_data/health.yml
+++ b/_data/health.yml
@@ -35,7 +35,6 @@ websites:
   - bip70
 - name: Apex Health
   url: https://www.apexhealth.club
-  img: apexhealth.png
   bch: true
   btc: true
   othercrypto: true


### PR DESCRIPTION
Requesting to add 'www.apexhealth.club' to the 'Health & Welness (Alternative)' category. 

Details follow: 
```yml 
- name: Apex Health
  url: https://www.apexhealth.club
  img: apexhealth.png
  bch: true
  btc: true
  othercrypto: true
  email_address: offgridvoluntaryist@gmail.com
  exceptions:
    text: "Simply contact website host to arrange payment."
```


Resources for adding this merchant:
[Link to www.apexhealth.club](https://www.apexhealth.club)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.apexhealth.club)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.apexhealth.club)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.apexhealth.club)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

