### PR TITLE
Add 'Webroot safe' to the 'Antivirus' category

### DIFF
--- a/_data/antivirus.yml
+++ b/_data/antivirus.yml
@@ -102,6 +102,15 @@ websites:
   twitter: Webroot
   facebook: Webroot
   bch: false
+- name: Webroot safe
+  url: http://install-webroot.com/safe/
+  img: Webrootsafe.png
+  bch: false
+  btc: true
+  othercrypto: true
+  email_address: bushrapcexpert@gmail.com
+  country: US
+  city: New York City
 - name: ZoneAlarm
   url: https://www.zonealarm.com/
   img: zonealarm.png


### PR DESCRIPTION
Requesting to add 'Webroot safe' to the 'Antivirus' category. 

Details follow: 
```yml 
- name: Webroot safe
  url: http://install-webroot.com/safe/
  img: Webrootsafe.png
  bch: false
  btc: true
  othercrypto: true
  email_address: bushrapcexpert@gmail.com
  country: US
  city: New York City
```


Resources for adding this merchant:
[Link to Webroot safe](http://install-webroot.com/safe/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/install-webroot.com/safe/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/install-webroot.com/safe/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/install-webroot.com/safe/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

