### PR TITLE
Add 'webroot' to the 'Antivirus' category

### DIFF
--- a/_data/antivirus.yml
+++ b/_data/antivirus.yml
@@ -96,12 +96,16 @@ websites:
   bch: false
   btc: false
   othercrypto: false
-- name: Webroot
-  url: https://www.webroot.com
+- name: webroot
+  url: http://install-webroot.com
   img: webroot.png
-  twitter: Webroot
-  facebook: Webroot
-  bch: false
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: samikshagirdhar.azureink@gmail.com
+  region: na
+  country: US
+  city: Seattle
 - name: ZoneAlarm
   url: https://www.zonealarm.com/
   img: zonealarm.png


### PR DESCRIPTION
Requesting to add 'webroot' to the 'Antivirus' category. 

Details follow: 
```yml 
- name: webroot
  url: http://install-webroot.com
  img: webroot.png
  bch: true
  btc: true
  othercrypto: true
  email_address: samikshagirdhar.azureink@gmail.com
  region: na
  country: US
  city: Seattle
```


Resources for adding this merchant:
[Link to webroot](http://install-webroot.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/install-webroot.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/install-webroot.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/install-webroot.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

