### PR TITLE
Add 'TewTew.com' to the 'Entertainment' category

### DIFF
--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -295,7 +295,6 @@ websites:
   facebook: spotify
 - name: TewTew.com
   url: https://TewTew.com
-  img: TewTewcom.png
   bch: true
   btc: false
   othercrypto: false

--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -293,6 +293,14 @@ websites:
   bch: false
   twitter: spotifycares
   facebook: spotify
+- name: TewTew.com
+  url: https://TewTew.com
+  img: TewTewcom.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: Eric@MobTwo.com
+  doc: https://TewTew.com/?action=showFAQFrame
 - name: The Dollar Vigilante
   url: https://dollarvigilante.com/
   twitter: DollarVigilante


### PR DESCRIPTION
Requesting to add 'TewTew.com' to the 'Entertainment' category. 

Details follow: 
```yml 
- name: TewTew.com
  url: https://TewTew.com
  img: TewTewcom.png
  bch: true
  btc: false
  othercrypto: false
  email_address: Eric@MobTwo.com
  doc: https://TewTew.com/?action=showFAQFrame
```


Resources for adding this merchant:
[Link to TewTew.com](https://TewTew.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/TewTew.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/TewTew.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/TewTew.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

