### PR TITLE
Add 'https://1BCH.com' to the 'Social' category

### DIFF
--- a/_data/social.yml
+++ b/_data/social.yml
@@ -1,5 +1,11 @@
 ---
 websites:
+- name: 1BCH.com
+  url: https://1BCH.com
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: Eric@MobTwo.com
 - name: 4chan
   url: https://www.4chan.org/
   img: 4chan.png
@@ -133,13 +139,6 @@ websites:
   bch: false
   twitter: hootsuite
   facebook: hootsuite
-- name: https://1BCH.com
-  url: https://1BCH.com
-  img: httpsBCHcom.png
-  bch: true
-  btc: false
-  othercrypto: false
-  email_address: Eric@MobTwo.com
 - name: ICQ
   url: https://icq.com/
   img: icq.png

--- a/_data/social.yml
+++ b/_data/social.yml
@@ -133,6 +133,13 @@ websites:
   bch: false
   twitter: hootsuite
   facebook: hootsuite
+- name: https://1BCH.com
+  url: https://1BCH.com
+  img: httpsBCHcom.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: Eric@MobTwo.com
 - name: ICQ
   url: https://icq.com/
   img: icq.png


### PR DESCRIPTION
Requesting to add 'https://1BCH.com' to the 'Social' category. 

Details follow: 
```yml 
- name: https://1BCH.com
  url: https://1BCH.com
  img: httpsBCHcom.png
  bch: true
  btc: false
  othercrypto: false
  email_address: Eric@MobTwo.com
```


Resources for adding this merchant:
[Link to https://1BCH.com](https://1BCH.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/1BCH.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/1BCH.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/1BCH.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

