### PR TITLE
Add 'PotOdds.cash' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -254,6 +254,13 @@ websites:
   bch: true
   btc: true
   othercrypto: false
+- name: PotOdds.cash
+  url: https://potodds.cash/
+  img: PotOddscash.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: potodds@protonmail.com
 - name: Primedice
   url: https://primedice.com/
   img: primedice.png


### PR DESCRIPTION
Requesting to add 'PotOdds.cash' to the 'Gambling' category. 

Details follow: 
```yml 
- name: PotOdds.cash
  url: https://potodds.cash/
  img: PotOddscash.png
  bch: true
  btc: false
  othercrypto: false
  email_address: potodds@protonmail.com
```


Resources for adding this merchant:
[Link to PotOdds.cash](https://potodds.cash/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/potodds.cash/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/potodds.cash/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/potodds.cash/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

