### PR TITLE
Add 'Contract for Crypto' to the 'Services' category

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -68,6 +68,18 @@ websites:
   bch: true
   btc: false
   othercrypto: true
+- name: Contract for Crypto
+  url: https://www.contractforcrypto.com/
+  img: ContractforCrypto.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: mreynoldsaurora@gmail.com
+  region: na
+  country: CA
+  city: Southern Ontario
+  exceptions:
+    text: "Depending on agreement of payment timeline for giving project"
 - name: COOL Networks
   url: http://cool.net.au
   img: coolnetworks.png

--- a/_data/services.yml
+++ b/_data/services.yml
@@ -70,7 +70,6 @@ websites:
   othercrypto: true
 - name: Contract for Crypto
   url: https://www.contractforcrypto.com/
-  img: ContractforCrypto.png
   bch: true
   btc: true
   othercrypto: true


### PR DESCRIPTION
Requesting to add 'Contract for Crypto' to the 'Private Contractor Home Renovations' category. 

Details follow: 
```yml 
- name: Contract for Crypto
  url: https://www.contractforcrypto.com/
  img: ContractforCrypto.png
  bch: true
  btc: true
  othercrypto: true
  email_address: mreynoldsaurora@gmail.com
  region: na
  country: CA
  city: Southern Ontario
  exceptions:
    text: "Depending on agreement of payment timeline for giving project"
```


Resources for adding this merchant:
[Link to Contract for Crypto](https://www.contractforcrypto.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.contractforcrypto.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.contractforcrypto.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.contractforcrypto.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

