### PR TITLE
Add 'VituVipi' to the 'Retail' category

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -2023,6 +2023,15 @@ websites:
   bch: true
   btc: true
   othercrypto: false
+- name: VituVipi
+  url: https://vituvipi.online
+  img: VituVipi.png
+  bch: true
+  btc: false
+  othercrypto: true
+  email_address: vituvipi@vituvipi.online
+  country: CD
+  city: Kinshasa 
 - name: Walgreens
   url: https://www.walgreens.com
   twitter: walgreens


### PR DESCRIPTION
Requesting to add 'VituVipi' to the 'Retail' category. 

Details follow: 
```yml 
- name: VituVipi
  url: https://vituvipi.online
  img: VituVipi.png
  bch: true
  btc: false
  othercrypto: true
  email_address: vituvipi@vituvipi.online
  country: CD
  city: Kinshasa 
```


Resources for adding this merchant:
[Link to VituVipi](https://vituvipi.online)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/vituvipi.online)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/vituvipi.online)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/vituvipi.online)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by @patnew
