### PR TITLE
Add 'Cryptolifestyle - Website Producers' to the 'Developer' category

### DIFF
--- a/_data/developer.yml
+++ b/_data/developer.yml
@@ -143,6 +143,12 @@ websites:
   bch: false
   twitter: contextio
   facebook: ContextIO
+- name: Cryptolifestyle - Website Producers
+  url: https://rocketr.net/sellers/cryptolifestyle
+  img: CryptolifestyleWebsiteProducers.png
+  bch: true
+  btc: false
+  othercrypto: false
 - name: Deploybot
   url: https://deploybot.com/
   img: deploybot.png


### PR DESCRIPTION
Requesting to add 'Cryptolifestyle - Website Producers' to the 'Developer' category. 

Details follow: 
```yml 
- name: Cryptolifestyle - Website Producers
  url: https://rocketr.net/sellers/cryptolifestyle
  img: CryptolifestyleWebsiteProducers.png
  bch: true
  btc: false
  othercrypto: false
```


Resources for adding this merchant:
[Link to Cryptolifestyle - Website Producers](https://rocketr.net/sellers/cryptolifestyle)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/rocketr.net/sellers/cryptolifestyle)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/rocketr.net/sellers/cryptolifestyle)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/rocketr.net/sellers/cryptolifestyle)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

