### PR TITLE
Add 'CORSO' to the 'Food' category

### DIFF
--- a/_data/food.yml
+++ b/_data/food.yml
@@ -216,6 +216,18 @@ websites:
   bch: true
   btc: false
   othercrypto: true
+- name: CORSO
+  url: https://www.facebook.com/caffebarcorsorasinja/
+  img: CORSO.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: ultrarik123@gmail.com
+  region: eu
+  country: HR
+  doc: https://www.facebook.com/groups/334085863723507/permalink/642110256254398/
+  exceptions:
+    text: "Use Bitcoin.com or Elipay wallet"
 - name: De Wine Spot
   url: https://dewinespot.co/
   img: dewinespot.png

--- a/_data/food.yml
+++ b/_data/food.yml
@@ -218,7 +218,6 @@ websites:
   othercrypto: true
 - name: CORSO
   url: https://www.facebook.com/caffebarcorsorasinja/
-  img: CORSO.png
   bch: true
   btc: true
   othercrypto: true


### PR DESCRIPTION
Requesting to add 'CORSO' to the 'Cafe bar' category. 

Details follow: 
```yml 
- name: CORSO
  url: https://www.facebook.com/caffebarcorsorasinja/
  img: CORSO.png
  bch: true
  btc: true
  othercrypto: true
  email_address: ultrarik123@gmail.com
  region: eu
  country: HR
  doc: https://www.facebook.com/groups/334085863723507/permalink/642110256254398/
  exceptions:
    text: "Use Bitcoin.com or Elipay wallet"
```


Resources for adding this merchant:
[Link to CORSO](https://www.facebook.com/caffebarcorsorasinja/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.facebook.com/caffebarcorsorasinja/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.facebook.com/caffebarcorsorasinja/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.facebook.com/caffebarcorsorasinja/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [ultrarik1](https://twitter.com/ultrarik1/), be sure to send out a tweet when this request has been added.
