### PR TITLE
Add 'Jumblo' to the 'Communication' category

### DIFF
--- a/_data/communication.yml
+++ b/_data/communication.yml
@@ -112,6 +112,12 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: Jumblo
+  url: https://www.jumblo.com
+  img: Jumblo.png
+  bch: true
+  btc: true
+  othercrypto: false
 - name: MailChimp
   url: https://mailchimp.com/
   img: mailchimp.png


### PR DESCRIPTION
Requesting to add 'Jumblo' to the 'Communication' category. 

Details follow: 
```yml 
- name: Jumblo
  url: https://www.jumblo.com
  img: Jumblo.png
  bch: true
  btc: true
  othercrypto: false
```


Resources for adding this merchant:
[Link to Jumblo](https://www.jumblo.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.jumblo.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.jumblo.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.jumblo.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

