### PR TITLE
Add 'CoinWin888' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -137,6 +137,13 @@ websites:
   btc: true
   othercrypto: false
   doc: https://www.cloudbet.com/en/bitcoin-cash-promotion
+- name: CoinWin888
+  url: https://coinwin888.com/
+  img: CoinWin.png
+  bch: true
+  btc: true
+  othercrypto: true
+  doc: http://www.coinwin888.com/news.html
 - name: Crypto Wild
   url: https://www.cryptowild.com/
   img: cryptowild.png

--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -138,12 +138,10 @@ websites:
   othercrypto: false
   doc: https://www.cloudbet.com/en/bitcoin-cash-promotion
 - name: CoinWin888
-  url: https://coinwin888.com/
-  img: CoinWin.png
+  url: https://www.coinwin888.com/
   bch: true
   btc: true
   othercrypto: true
-  doc: http://www.coinwin888.com/news.html
 - name: Crypto Wild
   url: https://www.cryptowild.com/
   img: cryptowild.png


### PR DESCRIPTION
Requesting to add 'CoinWin888' to the 'Gambling' category. 

Details follow: 
```yml 
- name: CoinWin888
  url: https://coinwin888.com/
  img: CoinWin.png
  bch: true
  btc: true
  othercrypto: true
  doc: http://www.coinwin888.com/news.html
```


Resources for adding this merchant:
[Link to CoinWin888](https://coinwin888.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/coinwin888.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/coinwin888.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/coinwin888.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

