### PR TITLE
closes #1701 - Adding warning to users

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -284,6 +284,8 @@ websites:
   doc: https://easy.gr/el/payment-methods
   keywords:
   - coinbase
+  exceptions: 
+    text: "Be aware that Easy.gr may ask for KYC information after accepting payment. This is not a recommended vendor for customers seeking privacy."
 - name: Fastly
   url: https://www.fastly.com
   twitter: fastly


### PR DESCRIPTION
closes #1701 to provide customers with infromation about this not being a good option for privacy.