### PR TITLE
Add 'Manna Cottage' to the 'Accommodation' category

### DIFF
--- a/_data/accommodation.yml
+++ b/_data/accommodation.yml
@@ -78,6 +78,15 @@ websites:
   bch: true
   btc: true
   othercrypto: false
+- name: Manna Cottage
+  url: https://www.mannacottage.com/
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: mannacottage@protonmail.com
+  region: eu
+  country: GR
+  city: Siros
 - name: Perivoli Guest Rooms
   url: https://www.guest-rooms.com
   img: perivoli.png


### PR DESCRIPTION
Requesting to add 'Manna Cottage' to the 'Rental Travel and Tourism' category. 

Details follow: 
```yml 
- name: Manna Cottage
  url: https://www.mannacottage.com/
  bch: true
  btc: true
  othercrypto: true
  email_address: mannacottage@protonmail.com
  region: eu
  country: GR
  city: Siros
```


Resources for adding this merchant:
[Link to Manna Cottage](https://www.mannacottage.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.mannacottage.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.mannacottage.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.mannacottage.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

