### PR TITLE
Add 'Satoshi Keys' to the 'Gaming' category

### DIFF
--- a/_data/gaming.yml
+++ b/_data/gaming.yml
@@ -451,6 +451,15 @@ websites:
   bch: false
   twitter: RuneScape
   facebook: RuneScape
+- name: Satoshi Keys
+  url: https://www.satoshikeys.com
+  img: SatoshiKeys.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: admin@satoshikeys.com
+  exceptions:
+    text: "No, just checkout with Coinpayments in the checkout screen."
 - name: SCDKey
   url: https://www.scdkey.com/
   img: scdkey.png


### PR DESCRIPTION
Requesting to add 'Satoshi Keys' to the 'Gaming' category. 

Details follow: 
```yml 
- name: Satoshi Keys
  url: https://www.satoshikeys.com
  img: SatoshiKeys.png
  bch: true
  btc: true
  othercrypto: true
  email_address: admin@satoshikeys.com
  exceptions:
    text: "No, just checkout with Coinpayments in the checkout screen."
```


Resources for adding this merchant:
[Link to Satoshi Keys](https://www.satoshikeys.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.satoshikeys.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.satoshikeys.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.satoshikeys.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

