### PR TITLE
Add 'moldavite jewelry' to the 'Jewelry' category

### DIFF
--- a/_data/jewelry.yml
+++ b/_data/jewelry.yml
@@ -187,6 +187,15 @@ websites:
   keywords:
   - bitpay
   - coinbase
+- name: moldavite jewelry
+  url: https://www.gemexi.com/gemstones/jewelry/moldavite
+  img: moldavitejewelry.png
+  bch: false
+  btc: false
+  othercrypto: false
+  email_address: tom.lincoln0001@gmail.com
+  region: eu
+  country: US
 - name: Moldavite Plus
   url: https://www.moldaviteplus.com/
   img: moldaviteplus.png


### PR DESCRIPTION
Requesting to add 'moldavite jewelry' to the 'Jewelry' category. 

Details follow: 
```yml 
- name: moldavite jewelry
  url: https://www.gemexi.com/gemstones/jewelry/moldavite
  img: moldavitejewelry.png
  bch: false
  btc: false
  othercrypto: false
  email_address: tom.lincoln0001@gmail.com
  region: eu
  country: US
```


Resources for adding this merchant:
[Link to moldavite jewelry](https://www.gemexi.com/gemstones/jewelry/moldavite)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.gemexi.com/gemstones/jewelry/moldavite)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.gemexi.com/gemstones/jewelry/moldavite)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.gemexi.com/gemstones/jewelry/moldavite)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

