### PR TITLE
Add 'The Cloud Gallery' to the 'Art' category

### DIFF
--- a/_data/art.yml
+++ b/_data/art.yml
@@ -136,13 +136,11 @@ websites:
   btc: true
   othercrypto: true
 - name: The Cloud Gallery
-  url: http://thecloudgallery.org/
-  img: thecloudgallery.png
-  email_address: curator@thecloudgallery.org
-  country: AU
-  bch: true
+  url: https://thecloudgallery.org
+  img: TheCloudGallery.png
+  bch: false
   btc: false
-  othercrypto: false
+  othercrypto: true
 - name: The Wall Today
   url: https://thewalltoday.com/en/
   img: thewalltoday.png


### PR DESCRIPTION
Requesting to add 'The Cloud Gallery' to the 'Art' category. 

Details follow: 
```yml 
- name: The Cloud Gallery
  url: https://thecloudgallery.org
  img: TheCloudGallery.png
  bch: false
  btc: false
  othercrypto: true
```


Resources for adding this merchant:
[Link to The Cloud Gallery](https://thecloudgallery.org)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/thecloudgallery.org)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/thecloudgallery.org)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/thecloudgallery.org)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

