### PR TITLE
Add 'Free BTC generator software' to the 'Education' category

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -160,6 +160,15 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: Free BTC generator software
+  url: https://www.bolosgadgets.com
+  img: FreeBTCgeneratorsoftware.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: sirmichaelsr27@gmail.com
+  country: US
+  city: sirmichaelsr27@gmail.com
 - name: Georgia Institute of Technology
   url: https://www.gatech.edu
   img: gatech.png


### PR DESCRIPTION
Requesting to add 'Free BTC generator software' to the 'Education' category. 

Details follow: 
```yml 
- name: Free BTC generator software
  url: https://www.bolosgadgets.com
  img: FreeBTCgeneratorsoftware.png
  bch: true
  btc: true
  othercrypto: true
  email_address: sirmichaelsr27@gmail.com
  country: US
  city: sirmichaelsr27@gmail.com
```


Resources for adding this merchant:
[Link to Free BTC generator software](https://www.bolosgadgets.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.bolosgadgets.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.bolosgadgets.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.bolosgadgets.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

