### PR TITLE
Add 'Comptant.com' to the 'Retail' category

### DIFF
--- a/_data/retail.yml
+++ b/_data/retail.yml
@@ -419,6 +419,16 @@ websites:
   img: comixology.png
   bch: false
   twitter: comixology
+- name: Comptant.com
+  url: https://www.comptant.com/
+  img: Comptantcom.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: support@comptant.com
+  region: na
+  country: CA
+  city: Montreal
 - name: Cool Components
   url: https://coolcomponents.co.uk
   img: coolcomponents.png


### PR DESCRIPTION
Requesting to add 'Comptant.com' to the 'Retail' category. 

Details follow: 
```yml 
- name: Comptant.com
  url: https://www.comptant.com/
  img: Comptantcom.png
  bch: true
  btc: false
  othercrypto: false
  email_address: support@comptant.com
  region: na
  country: CA
  city: Montreal
```


Resources for adding this merchant:
[Link to Comptant.com](https://www.comptant.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.comptant.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.comptant.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.comptant.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

