### PR TITLE
Add 'Winz.io' to the 'Entertainment' category

### DIFF
--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -333,6 +333,14 @@ websites:
   bch: false
   twitter: vimeo
   facebook: Vimeo
+- name: Winz.io
+  url: https://winz.io
+  img: Winzio.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: leo@winsgaming.io
+  doc: https://winz.io/payments
 - name: YouTube
   url: https://www.youtube.com/
   img: youtube.png


### PR DESCRIPTION
Requesting to add 'Winz.io' to the 'Entertainment' category. 

Details follow: 
```yml 
- name: Winz.io
  url: https://winz.io
  img: Winzio.png
  bch: true
  btc: true
  othercrypto: true
  email_address: leo@winsgaming.io
  doc: https://winz.io/payments
```


Resources for adding this merchant:
[Link to Winz.io](https://winz.io)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/winz.io)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/winz.io)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/winz.io)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

