### PR TITLE
Add 'MyVPN.run - Your personal VPN (PPTP, L2TP, OpenVPN)' to the 'Security' category

### DIFF
--- a/_data/security.yml
+++ b/_data/security.yml
@@ -280,6 +280,14 @@ websites:
   othercrypto: true
   keywords:
   - coinpayments.net
+- name: MyVPN.run - Your personal VPN (PPTP, L2TP, OpenVPN)
+  url: https://myvpn.run
+  img: MyVPNrunYourpersonalVPNPPTPLTPOpenVPN.png
+  bch: true
+  btc: true
+  othercrypto: true
+  region: as
+  country: RU
 - name: NordVPN
   url: https://www.nordvpn.com
   img: nordvpn.png


### PR DESCRIPTION
Requesting to add 'MyVPN.run - Your personal VPN (PPTP, L2TP, OpenVPN)' to the 'VPN' category. 

Details follow: 
```yml 
- name: MyVPN.run - Your personal VPN (PPTP, L2TP, OpenVPN)
  url: https://myvpn.run
  img: MyVPNrunYourpersonalVPNPPTPLTPOpenVPN.png
  bch: true
  btc: true
  othercrypto: true
  region: as
  country: RU
```


Resources for adding this merchant:
Logo Provided:
![ProvidedLogoURL](https://i.imgur.com/TcABSs2.png)
[Link to MyVPN.run - Your personal VPN (PPTP, L2TP, OpenVPN)](https://myvpn.run)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/myvpn.run)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/myvpn.run)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/myvpn.run)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

