### PR TITLE
Add 'jialine' to the 'Art' category

### DIFF
--- a/_data/art.yml
+++ b/_data/art.yml
@@ -84,6 +84,12 @@ websites:
   btc: true
   othercrypto: true
   doc: https://www.facebook.com/greymandesign/photos/a.1542343829244355/1541847729293965/?type=3&theater
+- name: jialine
+  url: https://www.jialine.co/
+  img: jialine.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: Liam Gaughan Music Lessons
   url: https://www.liamgaughan.com
   img: liamgaughan.png


### PR DESCRIPTION
Requesting to add 'jialine' to the 'Modern art works' category. 

Details follow: 
```yml 
- name: jialine
  url: https://www.jialine.co/
  img: jialine.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to jialine](https://www.jialine.co/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.jialine.co/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.jialine.co/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.jialine.co/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

