### PR TITLE
Add 'Immozentral' to the 'Other' category

### DIFF
--- a/_data/other.yml
+++ b/_data/other.yml
@@ -140,6 +140,16 @@ websites:
   bch: false
   twitter: immobilienscout
   facebook: ImmobilienScout24
+- name: Immozentral
+  url: https://www.immozentral.com
+  img: Immozentral.png
+  bch: false
+  btc: false
+  othercrypto: false
+  email_address: info@immozentral.com
+  region: eu
+  country: DE
+  city: no
 - name: Indeed
   url: https://www.indeed.com/
   img: indeed.png


### PR DESCRIPTION
Requesting to add 'Immozentral' to the 'Other' category. 

Details follow: 
```yml 
- name: Immozentral
  url: https://www.immozentral.com
  img: Immozentral.png
  bch: false
  btc: false
  othercrypto: false
  email_address: info@immozentral.com
  region: eu
  country: DE
  city: no
```


Resources for adding this merchant:
[Link to Immozentral](https://www.immozentral.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.immozentral.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.immozentral.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.immozentral.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

