### PR TITLE
Add 'WP-GPL' to the 'Software' category

### DIFF
--- a/_data/software.yml
+++ b/_data/software.yml
@@ -94,12 +94,11 @@ websites:
   doc: https://www.redfox.bz/bitcoin.html
 - name: WP-GPL
   url: https://wp-gpl.org
+  img: WPGPL.png
   bch: true
   btc: false
   othercrypto: true
   email_address: jack@wp-gpl.org
-  exceptions:
-    text: 'Note: GPL software can usually be obtained for free.'
 - name: XSplit
   url: https://www.xsplit.com/
   img: xsplit.png


### PR DESCRIPTION
Requesting to add 'WP-GPL' to the 'Software' category. 

Details follow: 
```yml 
- name: WP-GPL
  url: https://wp-gpl.org
  img: WPGPL.png
  bch: true
  btc: false
  othercrypto: true
  email_address: jack@wp-gpl.org
```


Resources for adding this merchant:
[Link to WP-GPL](https://wp-gpl.org)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/wp-gpl.org)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/wp-gpl.org)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/wp-gpl.org)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

