### PR TITLE
Add 'BESTBUYRDP' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -68,6 +68,13 @@ websites:
   btc: true
   othercrypto: true
   doc: https://www.bacloud.com/en/payment-methods
+- name: BESTBUYRDP
+  url: https://bestbuyrdp.com
+  img: BESTBUYRDP.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: bestbuyrdp@gmail.com
 - name: Binary Lane
   url: https://www.binarylane.com.au/
   img: binarylane.png


### PR DESCRIPTION
Requesting to add 'BESTBUYRDP' to the 'Hosting' category. 

Details follow: 
```yml 
- name: BESTBUYRDP
  url: https://bestbuyrdp.com
  img: BESTBUYRDP.png
  bch: true
  btc: true
  othercrypto: true
  email_address: bestbuyrdp@gmail.com
```


Resources for adding this merchant:
[Link to BESTBUYRDP](https://bestbuyrdp.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/bestbuyrdp.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/bestbuyrdp.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/bestbuyrdp.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

