### PR TITLE
Add 'LyraHosting' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -628,6 +628,16 @@ websites:
   bch: false
   twitter: liquidweb
   facebook: liquidwebinc
+- name: LyraHosting
+  url: https://lyrahosting.com/
+  img: LyraHosting.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: info@lyrahosting.com
+  city: Global
+  exceptions:
+    text: "Absolutely not!"
 - name: Mammoth Networks
   url: https://www.mammoth.net.au/
   img: mammothnetworks.png


### PR DESCRIPTION
Requesting to add 'LyraHosting' to the 'Hosting' category. 

Details follow: 
```yml 
- name: LyraHosting
  url: https://lyrahosting.com/
  img: LyraHosting.png
  bch: true
  btc: true
  othercrypto: true
  email_address: info@lyrahosting.com
  city: Global
  exceptions:
    text: "Absolutely not!"
```


Resources for adding this merchant:
[Link to LyraHosting](https://lyrahosting.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/lyrahosting.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/lyrahosting.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/lyrahosting.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

