### PR TITLE
Add 'Bay Area Corporate Counsel' to the 'Legal' category

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -1,5 +1,14 @@
 ---
 websites:
+- name: Bay Area Corporate Counsel
+  url: https://www.bayareacorporatecounsel.com/
+  img: BayAreaCorporateCounsel.png
+  bch: true
+  btc: false
+  othercrypto: true
+  email_address: frank@bayareacorporatecounsel.com
+  region: na
+  country: US
 - name: Cosmolex
   url: https://www.cosmolex.com/
   img: cosmolex.png


### PR DESCRIPTION
Requesting to add 'Bay Area Corporate Counsel' to the 'Legal' category. 

Details follow: 
```yml 
- name: Bay Area Corporate Counsel
  url: https://www.bayareacorporatecounsel.com/
  img: BayAreaCorporateCounsel.png
  bch: true
  btc: false
  othercrypto: true
  email_address: frank@bayareacorporatecounsel.com
  region: na
  country: US
```


Resources for adding this merchant:
[Link to Bay Area Corporate Counsel](https://www.bayareacorporatecounsel.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.bayareacorporatecounsel.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.bayareacorporatecounsel.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.bayareacorporatecounsel.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

