### PR TITLE
Add 'Bagyatech' to the 'Education' category

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -31,6 +31,15 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: Bagyatech
+  url: http://www.bagyatech.com/
+  img: Bagyatech.png
+  bch: false
+  btc: false
+  othercrypto: false
+  region: na
+  country: US
+  city: Jamaica 
 - name: CBT Nuggets
   url: https://www.cbtnuggets.com/
   img: cbtnuggets.png


### PR DESCRIPTION
Requesting to add 'Bagyatech' to the 'Education' category. 

Details follow: 
```yml 
- name: Bagyatech
  url: http://www.bagyatech.com/
  img: Bagyatech.png
  bch: false
  btc: false
  othercrypto: false
  region: na
  country: US
  city: Jamaica 
```


Resources for adding this merchant:
[Link to Bagyatech](http://www.bagyatech.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.bagyatech.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.bagyatech.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.bagyatech.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by @vasantha
