### PR TITLE
Add 'CryptoCasinos' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -170,6 +170,13 @@ websites:
   bsv: false
   btc: true
   othercrypto: true
+- name: CryptoCasinos
+  url: https://cryptocasinos.com/
+  img: CryptoCasinos.png
+  bch: true
+  btc: true
+  othercrypto: true
+  region: na
 - name: CryptoThrills
   url: https://www.cryptothrills.io
   img: CryptoThrills.png


### PR DESCRIPTION
Requesting to add 'CryptoCasinos' to the 'Gambling' category. 

Details follow: 
```yml 
- name: CryptoCasinos
  url: https://cryptocasinos.com/
  img: CryptoCasinos.png
  bch: true
  btc: true
  othercrypto: true
  region: na
```


Resources for adding this merchant:
[Link to CryptoCasinos](https://cryptocasinos.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/cryptocasinos.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/cryptocasinos.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/cryptocasinos.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

