### PR TITLE
Add 'hindidarshan' to the 'Education' category

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -193,6 +193,16 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: hindidarshan
+  url: https://www.hindidarshan.com/
+  img: hindidarshan.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: shambhudayalsharma009@gmail.com
+  region: as
+  country: IN
+  city: JAIPUR
 - name: Illinois Institute Of Technology
   url: https://web.iit.edu/
   twitter: illinoistech


### PR DESCRIPTION
Requesting to add 'hindidarshan' to the 'Education' category. 

Details follow: 
```yml 
- name: hindidarshan
  url: https://www.hindidarshan.com/
  img: hindidarshan.png
  bch: true
  btc: false
  othercrypto: false
  email_address: shambhudayalsharma009@gmail.com
  region: as
  country: IN
  city: JAIPUR
```


Resources for adding this merchant:
[Link to hindidarshan](https://www.hindidarshan.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.hindidarshan.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.hindidarshan.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.hindidarshan.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

