### PR TITLE
Add 'Preciousbitmetals' to the 'Jewelry' category

### DIFF
--- a/_data/jewelry.yml
+++ b/_data/jewelry.yml
@@ -211,6 +211,14 @@ websites:
   othercrypto: true
   keywords:
   - bitpay
+- name: Preciousbitmetals
+  url: https://preciousbitmetals.nl/
+  img: Preciousbitmetals.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: support@preciousbitmetals.nl
+  region: eu
 - name: Provident Metals
   url: https://www.providentmetals.com/
   img: providentmetals.png


### PR DESCRIPTION
Requesting to add 'Preciousbitmetals' to the 'Jewelry' category. 

Details follow: 
```yml 
- name: Preciousbitmetals
  url: https://preciousbitmetals.nl/
  img: Preciousbitmetals.png
  bch: true
  btc: true
  othercrypto: true
  email_address: support@preciousbitmetals.nl
  region: eu
```


Resources for adding this merchant:
[Link to Preciousbitmetals](https://preciousbitmetals.nl/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/preciousbitmetals.nl/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/preciousbitmetals.nl/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/preciousbitmetals.nl/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

