### PR TITLE
Add 'Coinspice' to the 'Apparel' category

### DIFF
--- a/_data/apparel.yml
+++ b/_data/apparel.yml
@@ -143,6 +143,16 @@ websites:
   othercrypto: true
   keywords:
   - cryptocurrencycheckout
+- name: Coinspice
+  url: https://store.coinspice.io/
+  img: Coinspice.png
+  bch: true
+  btc: false
+  othercrypto: false
+  facebook: thiscoinspicewebsiteneedstoberemovednotinbusinesslost$15inbchonit.
+  email_address: falconwings24@gmail.com
+  region: na
+  country: US
 - name: CoinSpice Store
   url: https://store.coinspice.io/
   img: coinspicestore.png


### PR DESCRIPTION
Requesting to add 'Coinspice' to the 'Apparel' category. 

Details follow: 
```yml 
- name: Coinspice
  url: https://store.coinspice.io/
  img: Coinspice.png
  bch: true
  btc: false
  othercrypto: false
  facebook: thiscoinspicewebsiteneedstoberemovednotinbusinesslost$15inbchonit.
  email_address: falconwings24@gmail.com
  region: na
  country: US
```


Resources for adding this merchant:
[Link to Coinspice](https://store.coinspice.io/)
Check their Facebook Page: [fb.com/thiscoinspicewebsiteneedstoberemovednotinbusinesslost$15inbchonit.](https://fb.com/thiscoinspicewebsiteneedstoberemovednotinbusinesslost$15inbchonit.)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/store.coinspice.io/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/store.coinspice.io/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/store.coinspice.io/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

