### PR TITLE
Add 'Softwarefritz' to the 'Software' category

### DIFF
--- a/_data/software.yml
+++ b/_data/software.yml
@@ -92,6 +92,14 @@ websites:
   btc: true
   othercrypto: true
   doc: https://www.redfox.bz/bitcoin.html
+- name: Softwarefritz
+  url: https://softwarefritz.com/
+  img: Softwarefritz.png
+  bch: true
+  btc: false
+  othercrypto: true
+  region: eu
+  country: DE
 - name: WP-GPL
   url: https://wp-gpl.org
   bch: true


### PR DESCRIPTION
Requesting to add 'Softwarefritz' to the 'Software' category. 

Details follow: 
```yml 
- name: Softwarefritz
  url: https://softwarefritz.com/
  img: Softwarefritz.png
  bch: true
  btc: false
  othercrypto: true
  region: eu
  country: DE
```


Resources for adding this merchant:
[Link to Softwarefritz](https://softwarefritz.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/softwarefritz.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/softwarefritz.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/softwarefritz.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

