### PR TITLE
Add 'keysincaves' to the 'Services' category

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -304,6 +304,13 @@ websites:
   - bitpay
   - coingate
   - webmoney
+- name: keysincaves
+  url: https://keysincaves.com/
+  img: keysincaves.png
+  bch: false
+  btc: true
+  othercrypto: true
+  email_address: support@keysincaves.com
 - name: KNW refrigeration
   url: http://www.knw-refrigeration.co.za
   img: knwRefrigeration.png


### PR DESCRIPTION
Requesting to add 'keysincaves' to the 'Services' category. 

Details follow: 
```yml 
- name: keysincaves
  url: https://keysincaves.com/
  img: keysincaves.png
  bch: false
  btc: true
  othercrypto: true
  email_address: support@keysincaves.com
```


Resources for adding this merchant:
[Link to keysincaves](https://keysincaves.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/keysincaves.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/keysincaves.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/keysincaves.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

