### PR TITLE
Add '1 Bitcon Cash' to the 'Services' category

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -1,5 +1,11 @@
 ---
 websites:
+- name: 1 Bitcon Cash
+  url: https://www.1bitcoincash.com/
+  img: BitconCash.png
+  bch: true
+  btc: false
+  othercrypto: false
 - name: AdoramaPix
   url: https://www.adoramapix.com
   img: adoramapix.png


### PR DESCRIPTION
Requesting to add '1 Bitcon Cash' to the 'Services' category. 

Details follow: 
```yml 
- name: 1 Bitcon Cash
  url: https://www.1bitcoincash.com/
  img: BitconCash.png
  bch: true
  btc: false
  othercrypto: false
```


Resources for adding this merchant:
[Link to 1 Bitcon Cash](https://www.1bitcoincash.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.1bitcoincash.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.1bitcoincash.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.1bitcoincash.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

