### PR TITLE
Add 'fiveonefour' to the 'Art' category

### DIFF
--- a/_data/art.yml
+++ b/_data/art.yml
@@ -66,6 +66,16 @@ websites:
   twitter: dropbobdesigns
   facebook: dropbobdesigns
   email_address: info@dropbob.ca
+- name: fiveonefour
+  url: lamariejane.com
+  img: fiveonefour.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: fiveonefourjpeg@protonmail.com
+  region: na
+  exceptions:
+    text: "One step at a time"
 - name: FRAKTALITY
   url: https://fraktality.com/
   img: fraktality.png


### PR DESCRIPTION
Requesting to add 'fiveonefour' to the 'Art' category. 

Details follow: 
```yml 
- name: fiveonefour
  url: lamariejane.com
  img: fiveonefour.png
  bch: true
  btc: true
  othercrypto: true
  email_address: fiveonefourjpeg@protonmail.com
  region: na
  exceptions:
    text: "One step at a time"
```


Resources for adding this merchant:
[Link to fiveonefour](lamariejane.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/lamariejane.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/lamariejane.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/lamariejane.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

