### PR TITLE
Add 'Jackpot jill' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -205,6 +205,14 @@ websites:
   btc: true
   othercrypto: true
   doc: https://fortunejack.com/bitcoincash-gambling
+- name: Jackpot jill
+  url: www.jackpotjill.com
+  img: Jackpotjill.png
+  bch: true
+  btc: true
+  othercrypto: true
+  region: oc
+  country: AU
 - name: LuckyGames
   url: https://luckygames.io/
   twitter: luckygamesio


### PR DESCRIPTION
Requesting to add 'Jackpot jill' to the 'Gambling' category. 

Details follow: 
```yml 
- name: Jackpot jill
  url: www.jackpotjill.com
  img: Jackpotjill.png
  bch: true
  btc: true
  othercrypto: true
  region: oc
  country: AU
```


Resources for adding this merchant:
[Link to Jackpot jill](www.jackpotjill.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.jackpotjill.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.jackpotjill.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.jackpotjill.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

