### PR TITLE
Add 'Adult Magazines' to the 'adult' category

### DIFF
--- a/_data/adult.yml
+++ b/_data/adult.yml
@@ -1,5 +1,12 @@
 ---
 websites:
+- name: Adult Magazines
+  url: https://adultmagazinespdf.com/
+  img: AdultMagazines.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: admin@adultmagazinespdf.com
 - name: Babes Network
   url: https://www.babesnetwork.com
   img: Babes.png


### PR DESCRIPTION
Requesting to add 'Adult Magazines' to the 'adult' category. 

Details follow: 
```yml 
- name: Adult Magazines
  url: https://adultmagazinespdf.com/
  img: AdultMagazines.png
  bch: true
  btc: true
  othercrypto: true
  email_address: admin@adultmagazinespdf.com
```


Resources for adding this merchant:
[Link to Adult Magazines](https://adultmagazinespdf.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/adultmagazinespdf.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/adultmagazinespdf.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/adultmagazinespdf.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

