### PR TITLE
Add 'HereBets.com' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -205,6 +205,13 @@ websites:
   btc: true
   othercrypto: true
   doc: https://fortunejack.com/bitcoincash-gambling
+- name: HereBets.com
+  url: https://herebets.com/
+  img: HereBetscom.png
+  bch: true
+  btc: false
+  othercrypto: false
+  email_address: mobtwoeric@gmail.com
 - name: LuckyGames
   url: https://luckygames.io/
   twitter: luckygamesio


### PR DESCRIPTION
Requesting to add 'HereBets.com' to the 'Gambling' category. 

Details follow: 
```yml 
- name: HereBets.com
  url: https://herebets.com/
  img: HereBetscom.png
  bch: true
  btc: false
  othercrypto: false
  email_address: mobtwoeric@gmail.com
```


Resources for adding this merchant:
[Link to HereBets.com](https://herebets.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/herebets.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/herebets.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/herebets.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

