### PR TITLE
Add 'Wild casino' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -406,6 +406,13 @@ websites:
   btc: true
   othercrypto: true
   doc: https://uptownaces.eu/banking/deposit-methods
+- name: Wild casino
+  url: https://www.wildcasino.ag/cashier
+  img: Wildcasino.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: brandnewused17@gmail.com
 - name: Win A Day Casino
   url: https://www.winadaycasino.eu/
   img: winadaycasino.png


### PR DESCRIPTION
Requesting to add 'Wild casino' to the 'Gambling' category. 

Details follow: 
```yml 
- name: Wild casino
  url: https://www.wildcasino.ag/cashier
  img: Wildcasino.png
  bch: true
  btc: true
  othercrypto: true
  email_address: brandnewused17@gmail.com
```


Resources for adding this merchant:
[Link to Wild casino](https://www.wildcasino.ag/cashier)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.wildcasino.ag/cashier)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.wildcasino.ag/cashier)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.wildcasino.ag/cashier)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

