### PR TITLE
Add 'Homeopathic Treatment Online' to the 'Health' category

### DIFF
--- a/_data/health.yml
+++ b/_data/health.yml
@@ -322,6 +322,14 @@ websites:
   othercrypto: false
   twitter: HintHealth
   facebook: hinthealth
+- name: Homeopathic Treatment Online
+  url: https://www.facebook.com/homeopathictreatmentonline/
+  img: HomeopathicTreatmentOnline.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: homeopathictreatmentonline
+  email_address: sendmespamnow@pm.me
 - name: iMedDo
   url: http://imeddo.com/
   img: imeddo.png


### PR DESCRIPTION
Requesting to add 'Homeopathic Treatment Online' to the 'Health' category. 

Details follow: 
```yml 
- name: Homeopathic Treatment Online
  url: https://www.facebook.com/homeopathictreatmentonline/
  img: HomeopathicTreatmentOnline.png
  bch: true
  btc: true
  othercrypto: true
  facebook: homeopathictreatmentonline
  email_address: sendmespamnow@pm.me
```


Resources for adding this merchant:
[Link to Homeopathic Treatment Online](https://www.facebook.com/homeopathictreatmentonline/)
Check their Facebook Page: [fb.com/homeopathictreatmentonline](https://fb.com/homeopathictreatmentonline)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.facebook.com/homeopathictreatmentonline/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.facebook.com/homeopathictreatmentonline/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.facebook.com/homeopathictreatmentonline/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

