### PR TITLE
Add 'Space Fucker' to the 'adult' category

### DIFF
--- a/_data/adult.yml
+++ b/_data/adult.yml
@@ -159,6 +159,15 @@ websites:
   bch: true
   btc: false
   othercrypto: false
+- name: Space Fucker
+  url: https://www.spacefucker.com
+  img: SpaceFucker.png
+  bch: true
+  btc: true
+  othercrypto: true
+  doc: https://www.spacefucker.com/threads/credit-card-crypto-donations.359773/
+  exceptions:
+    text: "Need to contact stuff. Prefer Bitcoin Cash as payment for membership due to low fees. As alternative possible to accept other crypto."
 - name: StasyQ
   url: https://www.stasyq.com
   img: stasyq.png


### PR DESCRIPTION
Requesting to add 'Space Fucker' to the 'adult' category. 

Details follow: 
```yml 
- name: Space Fucker
  url: https://www.spacefucker.com
  img: SpaceFucker.png
  bch: true
  btc: true
  othercrypto: true
  doc: https://www.spacefucker.com/threads/credit-card-crypto-donations.359773/
  exceptions:
    text: "Need to contact stuff. Prefer Bitcoin Cash as payment for membership due to low fees. As alternative possible to accept other crypto."
```


Resources for adding this merchant:
[Link to Space Fucker](https://www.spacefucker.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.spacefucker.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.spacefucker.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.spacefucker.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

