### PR TITLE
Add 'Rinulikes' to the 'Services' category

### DIFF
--- a/_data/services.yml
+++ b/_data/services.yml
@@ -488,6 +488,12 @@ websites:
   btc: false
   othercrypto: true
   doc: https://ramonlperez.weebly.com/about.html
+- name: Rinulikes
+  url: https://rinulikes.com/
+  img: Rinulikes.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: SEO Clerks
   url: https://www.seoclerk.com/
   img: seoclerks.png


### PR DESCRIPTION
Requesting to add 'Rinulikes' to the 'Services' category. 

Details follow: 
```yml 
- name: Rinulikes
  url: https://rinulikes.com/
  img: Rinulikes.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to Rinulikes](https://rinulikes.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/rinulikes.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/rinulikes.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/rinulikes.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

