### PR TITLE
Add 'Spreadsheets' to the 'Mining' category

### DIFF
--- a/_data/mining.yml
+++ b/_data/mining.yml
@@ -110,6 +110,15 @@ websites:
   othercrypto: true
   facebook: miningpoolitalia
   region: eu
+- name: Spreadsheets
+  url: gjohnjok@gmail.com
+  img: Spreadsheets.png
+  bch: true
+  btc: true
+  othercrypto: true
+  region: na
+  country: US
+  city: I think so 
 - name: Suprnova
   url: https://www.suprnova.cc/
   img: suprnova.png


### PR DESCRIPTION
Requesting to add 'Spreadsheets' to the 'Mining' category. 

Details follow: 
```yml 
- name: Spreadsheets
  url: gjohnjok@gmail.com
  img: Spreadsheets.png
  bch: true
  btc: true
  othercrypto: true
  region: na
  country: US
  city: I think so 
```


Resources for adding this merchant:
[Link to Spreadsheets](gjohnjok@gmail.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/gjohnjok@gmail.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/gjohnjok@gmail.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/gjohnjok@gmail.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [iwanttoknowhowmanybitcoinihave?](https://twitter.com/iwanttoknowhowmanybitcoinihave?/), be sure to send out a tweet when this request has been added.
