### PR TITLE
Add 'Private WebHost' to the 'Cloud' category

### DIFF
--- a/_data/cloud.yml
+++ b/_data/cloud.yml
@@ -135,6 +135,14 @@ websites:
   bch: false
   twitter: packethost
   facebook: getpacket
+- name: Private WebHost
+  url: https://privateweb.top/
+  img: PrivateWebHost.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: n/a
+  email_address: privhost@riseup.net
 - name: ProfitBricks
   url: https://www.profitbricks.de
   img: profitbricks.png


### PR DESCRIPTION
Requesting to add 'Private WebHost' to the 'Cloud' category. 

Details follow: 
```yml 
- name: Private WebHost
  url: https://privateweb.top/
  img: PrivateWebHost.png
  bch: true
  btc: true
  othercrypto: true
  facebook: n/a
  email_address: privhost@riseup.net
```


Resources for adding this merchant:
[Link to Private WebHost](https://privateweb.top/)
Check their Facebook Page: [fb.com/n/a](https://fb.com/n/a)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/privateweb.top/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/privateweb.top/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/privateweb.top/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

