### PR TITLE
Add 'SixNine.io' to the 'Entertainment' category

### DIFF
--- a/_data/entertainment.yml
+++ b/_data/entertainment.yml
@@ -256,6 +256,13 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: SixNine.io
+  url: https://sixnine.io
+  img: SixNineio.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: sixnine@sixnine.io
 - name: Sling TV
   url: https://www.sling.com/
   img: sling.png


### PR DESCRIPTION
Requesting to add 'SixNine.io' to the 'Entertainment' category. 

Details follow: 
```yml 
- name: SixNine.io
  url: https://sixnine.io
  img: SixNineio.png
  bch: true
  btc: true
  othercrypto: true
  email_address: sixnine@sixnine.io
```


Resources for adding this merchant:
[Link to SixNine.io](https://sixnine.io)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/sixnine.io)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/sixnine.io)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/sixnine.io)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

