### PR TITLE
Add 'Liberty slots' to the 'Gambling' category

### DIFF
--- a/_data/gambling.yml
+++ b/_data/gambling.yml
@@ -205,6 +205,17 @@ websites:
   btc: true
   othercrypto: true
   doc: https://fortunejack.com/bitcoincash-gambling
+- name: Liberty slots
+  url: google.com
+  img: Libertyslots.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: sarahkfield7@outlook.com
+  country: AU
+  city: No
+  exceptions:
+    text: "bitcoincash:qzx6862c0jw6vhztr0rw4nz5xzvl47wvycdhesenxn"
 - name: LuckyGames
   url: https://luckygames.io/
   twitter: luckygamesio


### PR DESCRIPTION
Requesting to add 'Liberty slots' to the 'Gambling' category. 

Details follow: 
```yml 
- name: Liberty slots
  url: google.com
  img: Libertyslots.png
  bch: true
  btc: true
  othercrypto: true
  email_address: sarahkfield7@outlook.com
  country: AU
  city: No
  exceptions:
    text: "bitcoincash:qzx6862c0jw6vhztr0rw4nz5xzvl47wvycdhesenxn"
```


Resources for adding this merchant:
[Link to Liberty slots](google.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/google.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/google.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/google.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

