### PR TITLE
Add 'HostWonders' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -483,6 +483,14 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: HostWonders
+  url: https://hostwonders.com
+  img: HostWonders.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: hostwonders.com
+  email_address: support@hostwonders.com
 - name: Hudson Valley Host
   url: https://www.hudsonvalleyhost.com
   img: HudsonValleyHost.png


### PR DESCRIPTION
Requesting to add 'HostWonders' to the 'Hosting' category. 

Details follow: 
```yml 
- name: HostWonders
  url: https://hostwonders.com
  img: HostWonders.png
  bch: true
  btc: true
  othercrypto: true
  facebook: hostwonders.com
  email_address: support@hostwonders.com
```


Resources for adding this merchant:
[Link to HostWonders](https://hostwonders.com)
Check their Facebook Page: [fb.com/hostwonders.com](https://fb.com/hostwonders.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/hostwonders.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/hostwonders.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/hostwonders.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [hostwonders](https://twitter.com/hostwonders/), be sure to send out a tweet when this request has been added.
