### PR TITLE
Add 'Atomic Networks' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -69,6 +69,15 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: Atomic Networks
+  url: https://atomicnetworks.co/
+  img: AtomicNetworks.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: jacek@atomicnetworks.co
+  exceptions:
+    text: "Select "Cryptocurrency" as the Payment method in checkout."
 - name: BaCloud
   url: https://www.bacloud.com
   twitter: bacloud


### PR DESCRIPTION
Requesting to add 'Atomic Networks' to the 'Hosting' category. 

Details follow: 
```yml 
- name: Atomic Networks
  url: https://atomicnetworks.co/
  img: AtomicNetworks.png
  bch: true
  btc: true
  othercrypto: true
  email_address: jacek@atomicnetworks.co
  exceptions:
    text: "Select "Cryptocurrency" as the Payment method in checkout."
```


Resources for adding this merchant:
[Link to Atomic Networks](https://atomicnetworks.co/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/atomicnetworks.co/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/atomicnetworks.co/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/atomicnetworks.co/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

