### PR TITLE
Add 'Butcher Block Cafe' to the 'Food' category

### DIFF
--- a/_data/food.yml
+++ b/_data/food.yml
@@ -182,6 +182,15 @@ websites:
   bch: false
   btc: false
   othercrypto: false
+- name: Butcher Block Cafe
+  url: http://www.butcherblockcafe.com
+  img: ButcherBlockCafe.png
+  bch: false
+  btc: true
+  othercrypto: false
+  region: na
+  country: US
+  city: Denver
 - name: Classic Crust Pizza
   url: https://classiccrustpizza.com/
   img: classiccrustpizza.png


### PR DESCRIPTION
Requesting to add 'Butcher Block Cafe' to the 'Food' category. 

Details follow: 
```yml 
- name: Butcher Block Cafe
  url: http://www.butcherblockcafe.com
  img: ButcherBlockCafe.png
  bch: false
  btc: true
  othercrypto: false
  region: na
  country: US
  city: Denver
```


Resources for adding this merchant:
[Link to Butcher Block Cafe](http://www.butcherblockcafe.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.butcherblockcafe.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.butcherblockcafe.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.butcherblockcafe.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

