### PR TITLE
Add 'UtcPay' to the 'Cryptoservices' category

### DIFF
--- a/_data/cryptoservices.yml
+++ b/_data/cryptoservices.yml
@@ -664,6 +664,13 @@ websites:
   btc: true
   othercrypto: true
   doc: https://uphold.com/en/blog/posts/uphold/bitcoin-cash-live-on-uphold
+- name: UtcPay
+  url: https://www.utcpay.com/
+  img: UtcPay.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: jojo@utcpay.com
 - name: uTop.us
   url: https://utop.us/
   img: utopus.png


### PR DESCRIPTION
Requesting to add 'UtcPay' to the 'Cryptoservices' category. 

Details follow: 
```yml 
- name: UtcPay
  url: https://www.utcpay.com/
  img: UtcPay.png
  bch: true
  btc: true
  othercrypto: true
  email_address: jojo@utcpay.com
```


Resources for adding this merchant:
[Link to UtcPay](https://www.utcpay.com/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.utcpay.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.utcpay.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.utcpay.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

