### PR TITLE
Add 'Bitcoin.com.au' to the 'Cryptoexchanges' category

### DIFF
--- a/_data/cryptoexchanges.yml
+++ b/_data/cryptoexchanges.yml
@@ -143,6 +143,16 @@ websites:
   facebook: www.bitcoinvn.io
   email_address: support@bitcoinvn.io
   country: VN
+- name: Bitcoin.com.au
+  url: https://bitcoin.com.au/
+  img: Bitcoincomau.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: bitcoin.com.au
+  email_address: aaron@bitcoin.com.au
+  region: oc
+  country: AU
 - name: Bitcoin.de
   url: https://bitcoin.de
   img: bitcoinde.png


### PR DESCRIPTION
Requesting to add 'Bitcoin.com.au' to the 'Cryptoexchanges' category. 

Details follow: 
```yml 
- name: Bitcoin.com.au
  url: https://bitcoin.com.au/
  img: Bitcoincomau.png
  bch: true
  btc: true
  othercrypto: true
  facebook: bitcoin.com.au
  email_address: aaron@bitcoin.com.au
  region: oc
  country: AU
```


Resources for adding this merchant:
[Link to Bitcoin.com.au](https://bitcoin.com.au/)
Check their Facebook Page: [fb.com/bitcoin.com.au](https://fb.com/bitcoin.com.au)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/bitcoin.com.au/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/bitcoin.com.au/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/bitcoin.com.au/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

