### PR TITLE
Add 'Crypto Legal' to the 'Legal' category

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -5,6 +5,13 @@ websites:
   img: cosmolex.png
   bch: false
   twitter: cosmolexlegal
+- name: Crypto Legal
+  url: https://www.cryptolegal.uk
+  img: CryptoLegal.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: info@cryptolegal.uk
 - name: Docusign
   url: https://www.docusign.com
   img: docusign.png


### PR DESCRIPTION
Requesting to add 'Crypto Legal' to the 'Legal' category. 

Details follow: 
```yml 
- name: Crypto Legal
  url: https://www.cryptolegal.uk
  img: CryptoLegal.png
  bch: true
  btc: true
  othercrypto: true
  email_address: info@cryptolegal.uk
```


Resources for adding this merchant:
[Link to Crypto Legal](https://www.cryptolegal.uk)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.cryptolegal.uk)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.cryptolegal.uk)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.cryptolegal.uk)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [cryptolegaluk](https://twitter.com/cryptolegaluk/), be sure to send out a tweet when this request has been added.
