### PR TITLE
Add 'KTHZR' to the 'Software' category

### DIFF
--- a/_data/software.yml
+++ b/_data/software.yml
@@ -67,6 +67,17 @@ websites:
   othercrypto: true
   keywords:
   - coinify
+- name: KTHZR
+  url: https://www.ketahazure.com
+  img: KTHZR.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: ketahazure@ketahazure.com
+  country: JP
+  city: Tokyo
+  exceptions:
+    text: "www.ketahazure.com"
 - name: pcTattletale
   url: https://www.pctattletale.com/
   img: pctattletale.png


### PR DESCRIPTION
Requesting to add 'KTHZR' to the 'Software' category. 

Details follow: 
```yml 
- name: KTHZR
  url: https://www.ketahazure.com
  img: KTHZR.png
  bch: true
  btc: true
  othercrypto: true
  email_address: ketahazure@ketahazure.com
  country: JP
  city: Tokyo
  exceptions:
    text: "www.ketahazure.com"
```


Resources for adding this merchant:
[Link to KTHZR](https://www.ketahazure.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/www.ketahazure.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/www.ketahazure.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/www.ketahazure.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [ketahazure3](https://twitter.com/ketahazure3/), be sure to send out a tweet when this request has been added.
