### PR TITLE
Add 'kinorojewelry.com' to the 'Jewelry' category

### DIFF
--- a/_data/jewelry.yml
+++ b/_data/jewelry.yml
@@ -154,6 +154,16 @@ websites:
       All BTC / BCH Orders Receive a 3% Discount Relative to Credit Card/PayPal Pricing
   keywords:
   - bitpay
+- name: kinorojewelry.com
+  url: https://kinorojewelry.com/
+  img: kinorojewelrycom.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: kinorojewelry
+  email_address: info@kinorojewelry.com
+  region: na
+  country: US
 - name: KJC Gold Silver Bullion
   url: https://www.kjc-gold-silver-bullion.com.au/
   img: KJCGoldSilverBullion.png


### PR DESCRIPTION
Requesting to add 'kinorojewelry.com' to the 'Jewelry' category. 

Details follow: 
```yml 
- name: kinorojewelry.com
  url: https://kinorojewelry.com/
  img: kinorojewelrycom.png
  bch: true
  btc: true
  othercrypto: true
  facebook: kinorojewelry
  email_address: info@kinorojewelry.com
  region: na
  country: US
```


Resources for adding this merchant:
[Link to kinorojewelry.com](https://kinorojewelry.com/)
Check their Facebook Page: [fb.com/kinorojewelry](https://fb.com/kinorojewelry)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/kinorojewelry.com/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/kinorojewelry.com/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/kinorojewelry.com/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

