### PR TITLE
Add 'chipex.cc' to the 'Cryptoexchanges' category

### DIFF
--- a/_data/cryptoexchanges.yml
+++ b/_data/cryptoexchanges.yml
@@ -317,6 +317,12 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: chipex.cc
+  url: https://chipex.cc/
+  img: chipexcc.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: Cobinhood
   url: https://cobinhood.com/
   img: cobinhood.png


### PR DESCRIPTION
Requesting to add 'chipex.cc' to the 'Cryptoexchanges' category. 

Details follow: 
```yml 
- name: chipex.cc
  url: https://chipex.cc/
  img: chipexcc.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to chipex.cc](https://chipex.cc/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/chipex.cc/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/chipex.cc/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/chipex.cc/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

