### PR TITLE
Add 'CypherGoat' to the 'Cryptoexchanges' category

### DIFF
--- a/_data/cryptoexchanges.yml
+++ b/_data/cryptoexchanges.yml
@@ -460,6 +460,14 @@ websites:
   btc: true
   othercrypto: true
   doc: https://www.cryptofacilities.com/cryptocurrency-news/bch-usd-futures/
+- name: CypherGoat
+  url: https://cyphergoat.com
+  img: CypherGoat.png
+  bch: true
+  btc: true
+  othercrypto: true
+  email_address: support@cyphergoat.com
+  doc: https://www.reddit.com/r/Bitcoincash/comments/1ja9cxs/cyphergoat_launch_crypto_exchange_aggregator/
 - name: DSX
   url: https://dsx.uk/
   img: dsx.png


### PR DESCRIPTION
Requesting to add 'CypherGoat' to the 'Cryptoexchanges' category. 

Details follow: 
```yml 
- name: CypherGoat
  url: https://cyphergoat.com
  img: CypherGoat.png
  bch: true
  btc: true
  othercrypto: true
  email_address: support@cyphergoat.com
  doc: https://www.reddit.com/r/Bitcoincash/comments/1ja9cxs/cyphergoat_launch_crypto_exchange_aggregator/
```


Resources for adding this merchant:
[Link to CypherGoat](https://cyphergoat.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/cyphergoat.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/cyphergoat.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/cyphergoat.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by @4rkal
Request made by Twitter user [4rkal_](https://twitter.com/4rkal_/), be sure to send out a tweet when this request has been added.
