### PR TITLE
Add 'Delistepeque Coffee' to the 'Food' category

### DIFF
--- a/_data/food.yml
+++ b/_data/food.yml
@@ -245,6 +245,18 @@ websites:
   bch: true
   btc: false
   othercrypto: false
+- name: Delistepeque Coffee
+  url: https://delistepeque.kyte.site
+  img: DelistepequeCoffee.png
+  bch: true
+  btc: true
+  othercrypto: false
+  facebook: share/1r4tiuqxi5
+  email_address: manager@delistepeque.coffee
+  region: na
+  country: SV
+  city: Santiago Nonualco 
+  doc: https://www.facebook.com/share/r/1BgGnm2PVf/
 - name: DoorDash
   url: https://www.doordash.com
   img: doordash.png


### PR DESCRIPTION
Requesting to add 'Delistepeque Coffee' to the 'Food' category. 

Details follow: 
```yml 
- name: Delistepeque Coffee
  url: https://delistepeque.kyte.site
  img: DelistepequeCoffee.png
  bch: true
  btc: true
  othercrypto: false
  facebook: share/1r4tiuqxi5
  email_address: manager@delistepeque.coffee
  region: na
  country: SV
  city: Santiago Nonualco 
  doc: https://www.facebook.com/share/r/1BgGnm2PVf/
```


Resources for adding this merchant:
[Link to Delistepeque Coffee](https://delistepeque.kyte.site)
Check their Facebook Page: [fb.com/share/1r4tiuqxi5](https://fb.com/share/1r4tiuqxi5)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/delistepeque.kyte.site)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/delistepeque.kyte.site)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/delistepeque.kyte.site)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

