### PR TITLE
Add 'Hosting International' to the 'Hosting' category

### DIFF
--- a/_data/hosting.yml
+++ b/_data/hosting.yml
@@ -373,6 +373,14 @@ websites:
   bch: true
   btc: true
   othercrypto: true
+- name: Hosting International
+  url: https://hosting.international/
+  img: HostingInternational.png
+  bch: true
+  btc: true
+  othercrypto: true
+  facebook: profile.php?id=61555009447697
+  email_address: marketing@hosting.international
 - name: HostUp
   url: https://hostup.org/
   img: hostup.png


### PR DESCRIPTION
Requesting to add 'Hosting International' to the 'Hosting' category. 

Details follow: 
```yml 
- name: Hosting International
  url: https://hosting.international/
  img: HostingInternational.png
  bch: true
  btc: true
  othercrypto: true
  facebook: profile.php?id=61555009447697
  email_address: marketing@hosting.international
```


Resources for adding this merchant:
[Link to Hosting International](https://hosting.international/)
Check their Facebook Page: [fb.com/profile.php?id=61555009447697](https://fb.com/profile.php?id=61555009447697)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/hosting.international/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/hosting.international/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/hosting.international/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

Request made by Twitter user [x.com/hosting_intl](https://twitter.com/x.com/hosting_intl/), be sure to send out a tweet when this request has been added.
