### PR TITLE
Add 'The Kiprojects' to the 'Education' category

### DIFF
--- a/_data/education.yml
+++ b/_data/education.yml
@@ -344,6 +344,12 @@ websites:
   bch: true
   btc: true
   othercrypto: false
+- name: The Kiprojects
+  url: thekiprojects.com
+  img: TheKiprojects.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: Udacity
   url: https://www.udacity.com/
   twitter: udacity


### PR DESCRIPTION
Requesting to add 'The Kiprojects' to the 'Education' category. 

Details follow: 
```yml 
- name: The Kiprojects
  url: thekiprojects.com
  img: TheKiprojects.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to The Kiprojects](thekiprojects.com)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/thekiprojects.com)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/thekiprojects.com)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/thekiprojects.com)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

