### PR TITLE
Add 'AnotldCC' to the 'Domains' category

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -35,6 +35,12 @@ websites:
   email_address: expert-help@above.com
   twitter: above_domain
   facebook: above.domain
+- name: AnotldCC
+  url: https://anotld.cc/
+  img: AnotldCC.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: Bitdomain.BIZ
   url: http://www3.bitdomain.biz/
   img: bitdomain.png


### PR DESCRIPTION
Requesting to add 'AnotldCC' to the 'Domains' category. 

Details follow: 
```yml 
- name: AnotldCC
  url: https://anotld.cc/
  img: AnotldCC.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to AnotldCC](https://anotld.cc/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/anotld.cc/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/anotld.cc/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/anotld.cc/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

