### PR TITLE
Add 'tldprivacy.ru' to the 'Domains' category

### DIFF
--- a/_data/domains.yml
+++ b/_data/domains.yml
@@ -478,6 +478,12 @@ websites:
   twitter: STRATO_AG
   facebook: strato
   lang: de
+- name: tldprivacy.ru
+  url: https://tldprivacy.ru/
+  img: tldprivacyru.png
+  bch: true
+  btc: true
+  othercrypto: true
 - name: UK2
   url: https://www.uk2.net/
   img: uk2.png


### PR DESCRIPTION
Requesting to add 'tldprivacy.ru' to the 'Domains' category. 

Details follow: 
```yml 
- name: tldprivacy.ru
  url: https://tldprivacy.ru/
  img: tldprivacyru.png
  bch: true
  btc: true
  othercrypto: true
```


Resources for adding this merchant:
[Link to tldprivacy.ru](https://tldprivacy.ru/)
Maybe you might want to check their [Alexa Rank](https://www.alexa.com/siteinfo/tldprivacy.ru/)
Maybe you might want to check [Scam Adviser](https://www.scamadviser.com/check-website/tldprivacy.ru/)
Maybe you might want to check [Trust Pilot](https://www.trustpilot.com/review/tldprivacy.ru/)


- Verify site is legitimate and safe to list.
- Correct data in form if any is inaccurate.

If everything looks okay, Add it to the site:
- Assign to yourself when you begin work.
- Download and resize the image and put it into the proper img folder.
- Add listing alphabetically to proper .yml file.
- Commit changes mentioning this issue number with `closes #[ISSUE NUMBER HERE]`.

